### PR TITLE
fix: release PAT & CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: release
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - ".github/**"
-      - "terraform/**"
-      - "README.md"
+#   push:
+#     branches: ["main"]
+#     paths-ignore:
+#       - ".github/**"
+#       - "terraform/**"
+#       - "README.md"
 
 permissions:
   contents: write
@@ -70,7 +70,8 @@ jobs:
         with:
           body_path: GITHUB_CHANGELOG.md
           tag_name: ${{ steps.release.outputs.version }}
-          token: ${{ secrets.PAT_VERSION_BUMP}}
+          # PAT not required because it defaults to `github.token`
+          # token: ${{ secrets.PAT_VERSION_BUMP }}
 
       - id: clean_version
         run: |


### PR DESCRIPTION
# Description

The PAT used for publishing the release no longer works presumably as it was @Rakowskiii's token. This blocked CD.

Was getting the error "GitHub release failed with status: 404" which the issues on that [action's repo](https://github.com/softprops/action-gh-release) indicated this could be PAT issue, turns it was.

According to the [docs](https://github.com/softprops/action-gh-release#-customizing), token defaults to `github.token` which should work for our needs. We would need a PAT if we want a member of our's to be marked as the author of the release (rather than GitHub bot), or if we want to make a release on a different repo. But using the default is preferable otherwise as it avoids coupling the pipeline to a user's PAT. I believe this same change can be made across all of our repos.

This PR also reverts the "publish release on push to main" changes made in https://github.com/WalletConnect/notify-server/commit/528c1a8308c835678369b4156e2dc8daabb8966e as I think this was implemented due to the non-usage of PRs for making changes and is not common across our other repos.

Resolves #8 

## How Has This Been Tested?

Pushing to `main`, observing a successful release.

And then I reset the commit and force-pushed to remove from repo history, and deleted the release.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
