### PR TITLE
chore: delete response code

### DIFF
--- a/src/handlers/subscribe_topic.rs
+++ b/src/handlers/subscribe_topic.rs
@@ -33,6 +33,8 @@ pub struct SubscribeTopicData {
     dapp_url: String,
 }
 
+// TODO test idempotency
+
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     AuthedProjectId(project_id, _): AuthedProjectId,

--- a/src/handlers/webhooks/delete_webhook.rs
+++ b/src/handlers/webhooks/delete_webhook.rs
@@ -27,5 +27,5 @@ pub async fn handler(
         )
         .await?;
 
-    Ok(axum::http::StatusCode::OK.into_response())
+    Ok(axum::http::StatusCode::NO_CONTENT.into_response())
 }

--- a/src/handlers/webhooks/delete_webhook.rs
+++ b/src/handlers/webhooks/delete_webhook.rs
@@ -10,6 +10,8 @@ use {
     uuid::Uuid,
 };
 
+// TODO test idempotency
+
 pub async fn handler(
     AuthedProjectId(project_id, _): AuthedProjectId,
     Path((_, webhook_id)): Path<(String, Uuid)>,


### PR DESCRIPTION
# Description

Changes the delete endpoint response code from 200 to 204 to reflect the fact that there is no content in the response. This matches the response of the [update endpoint](https://github.com/WalletConnect/notify-server/blob/9eac65835b257783b8dc70d00bcff4c253e27046/src/handlers/webhooks/update_webhook.rs#L33).

Resolves #22

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
