### PR TITLE
fix: use new registry API endpoint for validating project secret

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -47,9 +47,7 @@ impl RegistryHttpClient {
         let res: RegistryAuthResponse = self
             .http_client
             .get(format!(
-                // TODO "{}/internal/project/validate-notify-keys?projectId={id}&secret={secret}",
-                // https://github.com/WalletConnect/explorer-api/issues/161
-                "{}/internal/project/validate-cast-keys?projectId={id}&secret={secret}",
+                "{}/internal/project/validate-notify-keys?projectId={id}&secret={secret}",
                 self.addr
             ))
             .send()


### PR DESCRIPTION
# Description

Use the new endpoint that was introduced in https://github.com/WalletConnect/explorer-api/issues/161

Resolves #43

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
