### PR TITLE
fix: swift validation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,12 +72,12 @@ jobs:
       environment: "STAGING"
 
   # TODO: Restore once swift is ready for notify
-  # validate-staging-swift:       
+  # validate-staging-swift:
   #   needs: deploy-infra-staging
   #   uses: ./.github/workflows/validate_swift.yml
   #   with:
   #     notify-endpoint: 'staging.notify.walletconnect.com'
-  #     relay-endpoint: 'staging.relay.walletconnect.com' 
+  #     relay-endpoint: 'staging.relay.walletconnect.com'
 
 
   ##############################################################################
@@ -87,7 +87,7 @@ jobs:
     needs:
       - get-version
       - validate-staging-rust
-      - validate-staging-swift
+    #   - validate-staging-swift
     uses: ./.github/workflows/deploy-infra.yml
     secrets: inherit
     with:
@@ -106,10 +106,9 @@ jobs:
 
 
   # TODO: Restore once swift is ready for notify
-  # validate-swift-prod:       
+  # validate-swift-prod:
   #   needs: [deploy-infra-prod]
   #   uses: ./.github/workflows/validate_swift.yml
   #   with:
   #     notify-endpoint: 'notify.walletconnect.com'
-  #     relay-endpoint: 'relay.walletconnect.com' 
-  
+  #     relay-endpoint: 'relay.walletconnect.com'


### PR DESCRIPTION
# Description

I pulled in changes from cast in #33 but looks like we disabled swift tests in notify-server repo at some point in-between. So disabling swift tests now

Resolves #46

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
