### PR TITLE
fix: notify subscribe tag in integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ export REGISTRY_AUTH_TOKEN=""
 
 export PUBLIC_IP="127.0.0.1"
 export NOTIFY_URL="127.0.0.1"
-export ENVIRONMENT="LOCAL"
 export DATABASE_URL=mongodb://admin:admin@localhost:27017/notify?authSource=admin
 export REDIS_POOL_SIZE=64
 export KEYPAIR_SEED=""

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -67,7 +67,7 @@ const TEST_ACCOUNT: &str = "eip155:123:123456789abcdef";
 
 #[tokio::test]
 async fn notify_properly_sending_message() {
-    let env = std::env::var("ENVIRONMENT").unwrap_or("STAGING".to_owned()); // TODO no default
+    let env = std::env::var("ENVIRONMENT").unwrap_or("LOCAL".to_owned());
     let project_id =
         std::env::var("TEST_PROJECT_ID").expect("Tests requires TEST_PROJECT_ID to be set");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -181,7 +181,7 @@ async fn notify_properly_sending_message() {
         .publish(
             subscribe_topic.into(),
             message,
-            4006,
+            4000,
             Duration::from_secs(30),
             false,
         )


### PR DESCRIPTION
# Description

CD integration tests were failing and I couldn't figure out why. Turns out I was using the push subscribe tag (4006) instead of the notify subscribe tag (4000) in my integration tests 🤦. Didn't see this locally when testing because my .env was configured with DEV environment which tests against the dev environment I had deployed before, of which was still running the previous version of the app that DID still allow the push subscribe tag.

Fixed the integration tests to use correct tag, and make it harder to test against non-local to prevent this issue in the future.

Resolves #55

## How Has This Been Tested?

Locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
