### PR TITLE
fix: tflint & auto-format

### DIFF
--- a/.env.terraform.example
+++ b/.env.terraform.example
@@ -5,7 +5,7 @@ export TF_VAR_project_id=""
 export TF_VAR_registry_auth_token=""
 
 # Obtain from: https://grafana.walletconnect.com -> /org/apikeys
-export GRAFANA_AUTH=""
+export TF_VAR_grafana_auth=""
 
 # Obtain from https://walletconnect.awsapps.com/start#/
 export AWS_ACCESS_KEY_ID=""

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -163,7 +163,7 @@ jobs:
         id: tf-plan-prod
         uses: WalletConnect/actions/terraform/plan/@1.0.3
         env:
-          GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
+          TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
           TF_VAR_keypair_seed: ${{ secrets.KEYPAIR_SEED }}
           TF_VAR_project_id: ${{secrets.PROJECT_ID}}

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -92,7 +92,7 @@ jobs:
         id: tf-plan-staging
         uses: WalletConnect/actions/terraform/plan/@1.0.3
         env:
-          GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
+          TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
           TF_VAR_keypair_seed: ${{ secrets.KEYPAIR_SEED }}
           TF_VAR_project_id: ${{secrets.PROJECT_ID}}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -105,7 +105,7 @@ jobs:
         id: tf-apply
         uses: WalletConnect/actions/terraform/apply/@1.0.3
         env:
-          GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
+          TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
           TF_VAR_image_version: ${{ inputs.version}}
           TF_VAR_keypair_seed: ${{inputs.environment}}_${{ secrets.KEYPAIR_SEED}}

--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ tf-fmt:
 
   if command -v terraform >/dev/null; then
     echo '==> Running terraform fmt'
-    terraform -chdir=terraform fmt -check -recursive
+    terraform -chdir=terraform fmt -recursive
   else
     echo '==> Terraform not found in PATH, skipping'
   fi

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -12,9 +12,9 @@ provider "aws" {
   }
 }
 
-# Expects GRAFANA_AUTH env variable to be set
 provider "grafana" {
-  url = "https://${var.grafana_endpoint}"
+  url  = "https://${var.grafana_endpoint}"
+  auth = var.grafana_auth
 }
 
 provider "random" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,3 +73,8 @@ variable "registry_auth_token" {
   description = "The auth token for registry"
   type        = string
 }
+
+variable "grafana_auth" {
+  description = "Grafana auth token"
+  type        = string
+}


### PR DESCRIPTION
# Description

Fixes:

```
$ just lint-tf
==> Running terraform fmt
╷
│ Error: Missing required argument
│ 
│   with provider["registry.terraform.io/grafana/grafana"],
│   on provider.tf line 15, in provider "grafana":
│   15: provider "grafana" {
│ 
│ "auth": one of `auth,cloud_api_key,oncall_access_token,sm_access_token` must be specified
╵
╷
│ Error: Missing required argument
│ 
│   with provider["registry.terraform.io/grafana/grafana"],
│   on provider.tf line 16, in provider "grafana":
│   16:   url = "https://${var.grafana_endpoint}"
│ 
│ "url": all of `auth,url` must be specified
╵
error: Recipe `tf-validate` failed with exit code 1
```

Also auto-format Terraform instead of just checking.

Resolves #57

## How Has This Been Tested?

Locally with dev env. CI not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
