### PR TITLE
feat: read replica & bump instance class

### DIFF
--- a/terraform/docdb/main.tf
+++ b/terraform/docdb/main.tf
@@ -51,6 +51,15 @@ resource "aws_docdb_cluster_instance" "docdb_instances" {
   promotion_tier     = 0
 }
 
+#tfsec:ignore:aws-documentdb-encryption-customer-key
+resource "aws_docdb_cluster_instance" "docdb_replica_instances" {
+  count              = var.replica_instances
+  identifier         = "${local.name_prefix}-replica-instance-${count.index}"
+  cluster_identifier = aws_docdb_cluster.docdb_primary.id
+  instance_class     = var.replica_instance_class
+  promotion_tier     = 1
+}
+
 resource "aws_docdb_subnet_group" "private_subnets" {
   name       = "${local.name_prefix}-private-subnet-group"
   subnet_ids = var.private_subnet_ids

--- a/terraform/docdb/variables.tf
+++ b/terraform/docdb/variables.tf
@@ -18,6 +18,14 @@ variable "primary_instances" {
   type = number
 }
 
+variable "replica_instance_class" {
+  type = string
+}
+
+variable "replica_instances" {
+  type = number
+}
+
 variable "allowed_ingress_cidr_blocks" {
   type = list(string)
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,22 +49,23 @@ data "aws_ecr_repository" "repository" {
   name = "notify-server"
 }
 
+# TODO rename to notify-docdb like on history: https://github.com/WalletConnect/gilgamesh/blob/102064e9cababd4908f30d7994ea149c5d05d95c/terraform/main.tf#L53
 module "keystore-docdb" {
   source = "./docdb"
 
   app_name                    = local.app_name
-  mongo_name                  = "keystore-docdb"
+  mongo_name                  = "keystore-docdb" # TODO use default?
   environment                 = terraform.workspace
-  default_database            = "keystore"
+  default_database            = "keystore" # TODO "notify"
   primary_instance_class      = var.docdb_primary_instance_class
   primary_instances           = var.docdb_primary_instances
+  replica_instance_class      = var.docdb_replica_instance_class
+  replica_instances           = var.docdb_replica_instances
   vpc_id                      = module.vpc.vpc_id
   private_subnet_ids          = module.vpc.private_subnets
   allowed_ingress_cidr_blocks = [module.vpc.vpc_cidr_block]
   allowed_egress_cidr_blocks  = [module.vpc.vpc_cidr_block]
 }
-
-
 
 module "ecs" {
   source = "./ecs"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,6 +30,14 @@ variable "docdb_primary_instances" {
   type = number
 }
 
+variable "docdb_replica_instance_class" {
+  type = string
+}
+
+variable "docdb_replica_instances" {
+  type = number
+}
+
 variable "keypair_seed" {
   type = string
 }

--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,4 +1,4 @@
-docdb_primary_instance_class = "db.t4g.medium"
+docdb_primary_instance_class = "db.r5.large"
 docdb_primary_instances      = 1
 docdb_replica_instance_class = "db.t4g.medium"
 docdb_replica_instances      = 1

--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,7 +1,7 @@
 docdb_primary_instance_class = "db.r5.large"
 docdb_primary_instances      = 1
-docdb_replica_instance_class = "db.t4g.medium"
-docdb_replica_instances      = 1
+docdb_replica_instance_class = "db.r5.large"
+docdb_replica_instances      = 0
 grafana_endpoint             = "g-e66b9a1a24.grafana-workspace.eu-central-1.amazonaws.com"
 
 

--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,5 +1,7 @@
 docdb_primary_instance_class = "db.t4g.medium"
 docdb_primary_instances      = 1
+docdb_replica_instance_class = "db.t4g.medium"
+docdb_replica_instances      = 1
 grafana_endpoint             = "g-e66b9a1a24.grafana-workspace.eu-central-1.amazonaws.com"
 
 

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,5 +1,7 @@
 docdb_primary_instance_class = "db.r5.large"
 docdb_primary_instances      = 1
+docdb_replica_instance_class = "db.t4g.medium"
+docdb_replica_instances      = 1
 grafana_endpoint             = "g-e66b9a1a24.grafana-workspace.eu-central-1.amazonaws.com"
 
 

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,6 +1,6 @@
 docdb_primary_instance_class = "db.r5.large"
 docdb_primary_instances      = 1
-docdb_replica_instance_class = "db.t4g.medium"
+docdb_replica_instance_class = "db.r5.large"
 docdb_replica_instances      = 1
 grafana_endpoint             = "g-e66b9a1a24.grafana-workspace.eu-central-1.amazonaws.com"
 

--- a/terraform/vars/staging.tfvars
+++ b/terraform/vars/staging.tfvars
@@ -1,4 +1,4 @@
-docdb_primary_instance_class = "db.t4g.medium"
+docdb_primary_instance_class = "db.r5.large"
 docdb_primary_instances      = 1
 docdb_replica_instance_class = "db.t4g.medium"
 docdb_replica_instances      = 1

--- a/terraform/vars/staging.tfvars
+++ b/terraform/vars/staging.tfvars
@@ -1,7 +1,7 @@
 docdb_primary_instance_class = "db.r5.large"
 docdb_primary_instances      = 1
-docdb_replica_instance_class = "db.t4g.medium"
-docdb_replica_instances      = 1
+docdb_replica_instance_class = "db.r5.large"
+docdb_replica_instances      = 0
 grafana_endpoint             = "g-e66b9a1a24.grafana-workspace.eu-central-1.amazonaws.com"
 
 

--- a/terraform/vars/staging.tfvars
+++ b/terraform/vars/staging.tfvars
@@ -1,5 +1,7 @@
 docdb_primary_instance_class = "db.t4g.medium"
 docdb_primary_instances      = 1
+docdb_replica_instance_class = "db.t4g.medium"
+docdb_replica_instances      = 1
 grafana_endpoint             = "g-e66b9a1a24.grafana-workspace.eu-central-1.amazonaws.com"
 
 


### PR DESCRIPTION
# Description

Fix low available memory alarm by upgrading from `t4g.medium` (4GB) to `r5.large` (16GB). We use `r5` on relay and history server and `r6g` on keys server which is why I changed instance type to memory optimized (`r`).

Also fix CPU alarm. Issue was new grafonnet dashboards included references to read replicas. We didn't have read replicas, but relay and keys server did (not history), so adding them here too + for future prep. Hopefully we will switch to Postgres soon though.

Resolves #40  
Resolves #61 

## How Has This Been Tested?

Dev environment

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
