### PR TITLE
fix: subscribed metrics

### DIFF
--- a/terraform/monitoring/panels/app/account_not_found.libsonnet
+++ b/terraform/monitoring/panels/app/account_not_found.libsonnet
@@ -17,6 +17,6 @@ local targets   = grafana.targets;
       expr          = 'sum by(aws_ecs_task_revision) (increase(dispatched_notifications_total{type="not_found"}[$__rate_interval]))',
       legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
-      refId       = 'AccountsNotFound',
+      refId       = 'NotificationsNotFound',
     ))
 }

--- a/terraform/monitoring/panels/app/dispatched_notifications.libsonnet
+++ b/terraform/monitoring/panels/app/dispatched_notifications.libsonnet
@@ -17,6 +17,6 @@ local targets   = grafana.targets;
       expr          = 'sum by(aws_ecs_task_revision) (increase(dispatched_notifications_total{type="sent"}[$__rate_interval]))',
       legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
-      refId       = 'Sent',
+      refId       = 'NotificationsSent',
     ))
 }

--- a/terraform/monitoring/panels/app/send_failed.libsonnet
+++ b/terraform/monitoring/panels/app/send_failed.libsonnet
@@ -55,6 +55,6 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       expr          = 'sum by(aws_ecs_task_revision) (increase(dispatched_notifications_total{type="failed"}[$__rate_interval]))',
       legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
-      refId       = 'Failed',
+      refId       = 'NotificationsFailed',
     ))
 }

--- a/terraform/monitoring/panels/app/subscribed_client_topics.libsonnet
+++ b/terraform/monitoring/panels/app/subscribed_client_topics.libsonnet
@@ -17,6 +17,6 @@ local targets   = grafana.targets;
       expr          = 'subscribed_client_topics',
       legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
-      refId       = 'Subscribed Client Topics',
+      refId       = 'SubscribedClientTopics',
     ))
 }

--- a/terraform/monitoring/panels/app/subscribed_client_topics.libsonnet
+++ b/terraform/monitoring/panels/app/subscribed_client_topics.libsonnet
@@ -15,7 +15,7 @@ local targets   = grafana.targets;
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'subscribed_client_topics',
-      legendFormat  = 'Subscribed Client Topics',
+      legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
       refId       = 'Subscribed Client Topics',
     ))

--- a/terraform/monitoring/panels/app/subscribed_client_topics.libsonnet
+++ b/terraform/monitoring/panels/app/subscribed_client_topics.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = 'sum(increase(subscribed_client_topics[$__rate_interval]))',
+      expr          = 'subscribed_client_topics',
       legendFormat  = 'Subscribed Client Topics',
       exemplar      = true,
       refId       = 'Subscribed Client Topics',

--- a/terraform/monitoring/panels/app/subscribed_project_topics.libsonnet
+++ b/terraform/monitoring/panels/app/subscribed_project_topics.libsonnet
@@ -17,6 +17,6 @@ local targets   = grafana.targets;
       expr          = 'subscribed_project_topics',
       legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
-      refId       = 'Subscribed Project Topics',
+      refId       = 'SubscribedProjectTopics',
     ))
 }

--- a/terraform/monitoring/panels/app/subscribed_project_topics.libsonnet
+++ b/terraform/monitoring/panels/app/subscribed_project_topics.libsonnet
@@ -15,7 +15,7 @@ local targets   = grafana.targets;
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'subscribed_project_topics',
-      legendFormat  = 'Subscribed Project Topics',
+      legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
       refId       = 'Subscribed Project Topics',
     ))

--- a/terraform/monitoring/panels/app/subscribed_project_topics.libsonnet
+++ b/terraform/monitoring/panels/app/subscribed_project_topics.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = 'sum(increase(subscribed_project_topics[$__rate_interval]))',
+      expr          = 'subscribed_project_topics',
       legendFormat  = 'Subscribed Project Topics',
       exemplar      = true,
       refId       = 'Subscribed Project Topics',


### PR DESCRIPTION
# Description

Fix Subscribed Project Topics and Subscribed Client Topics showing 0. Since these are gauge metrics and not counters, `increase()` actually breaks this as the gauges don't increase that often.

Update legend for these. Since not using `sum()` we get one metric/new legend for each revision (unique combination of labels). If we use `sum()` then there is a 2x spike during rollout as there are two revisions each with the same value. Not using `sum()` results in multiple legends. Changing from generic name to revision name to make it more clear why there are multiple colors/legends.

Update refIds to be more "programatic".

Resolves #63

## How Has This Been Tested?

By hand via prod Grafana

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
