### PR TITLE
feat: verify keys server Cacao

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,7 +3021,7 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=c3ae6d4#c3ae6d49978ec3566fd2469f4dc199dda6d998ee"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=55d74d5#55d74d5c8edaef10e6cacf692febbc56a8970b80"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=c3ae6d4#c3ae6d49978ec3566fd2469f4dc199dda6d998ee"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=55d74d5#55d74d5c8edaef10e6cacf692febbc56a8970b80"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,16 +1010,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.6",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version 0.4.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1243,17 +1257,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
+name = "ed25519"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
 dependencies = [
- "curve25519-dalek 3.2.0",
- "ed25519",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "pkcs8",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -1262,10 +1272,24 @@ version = "1.0.1"
 source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65#7529d65506147b6cb24ca6d8f4fc062cac33b395"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.0.0",
+ "ed25519 2.2.2",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -2030,12 +2054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,7 +2312,7 @@ dependencies = [
  "deadpool-redis",
  "derive_more",
  "dotenv",
- "ed25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 2.0.0",
  "envy",
  "futures",
  "gorgon",
@@ -2303,6 +2321,7 @@ dependencies = [
  "hyper",
  "ipnet",
  "jsonwebtoken",
+ "k256",
  "lazy_static",
  "log",
  "mongodb",
@@ -2324,6 +2343,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha256",
+ "sha3",
  "test-context",
  "thiserror",
  "tokio",
@@ -2579,16 +2599,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm",
-]
 
 [[package]]
 name = "parking_lot"
@@ -3040,7 +3050,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "derive_more",
- "ed25519-dalek 1.0.1 (git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65)",
+ "ed25519-dalek 1.0.1",
  "jsonwebtoken",
  "k256",
  "once_cell",
@@ -4593,11 +4603,11 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0-rc.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabd6e16dd08033932fc3265ad4510cc2eab24656058a6dcb107ffe274abcc95"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 4.0.0-rc.2",
+ "curve25519-dalek 4.0.0",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,7 +3021,7 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435#5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=c3ae6d4#c3ae6d49978ec3566fd2469f4dc199dda6d998ee"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435#5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=c3ae6d4#c3ae6d49978ec3566fd2469f4dc199dda6d998ee"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,8 @@ async-tungstenite = { version = "0.20.0", features = [
 ] }
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435", features = [
-    "cacao",
-] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "c3ae6d4", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "c3ae6d4" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ async-tungstenite = { version = "0.20.0", features = [
 ] }
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "c3ae6d4", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "c3ae6d4" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "55d74d5", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "55d74d5" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tungstenite = { version = "0.18.0", features = ["native-tls"] }
 url = "2.3.1"
 sha256 = "1.1.1"
 chacha20poly1305 = "0.10.1"
-ed25519-dalek = "1.0.1"
+ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 rand = "0.7.0"
 rand_core = "0.5.0"
 ring = "0.16.20"
@@ -90,7 +90,7 @@ relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", re
     "cacao",
 ] }
 relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "5f4dd3cbf4a67e40c47503706f8e0ae8d8bdd435" }
-x25519-dalek = { version = "2.0.0-rc.2", features = ["static_secrets"] }
+x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"
 uuid = { version = "1.3.1", features = ["serde", "v4"] }
@@ -105,7 +105,13 @@ rmp-serde = "1.1.1"
 deadpool-redis = "0.12.0"
 
 [dev-dependencies]
+sha3 = "0.10.8"
+k256 = "0.13.1"
 test-context = "0.1"
 
 [build-dependencies]
 build-info-build = "0.0"
+
+# [patch.'https://github.com/WalletConnect/WalletConnectRust.git']
+# relay_rpc = { path = "../WalletConnectRust/relay_rpc" }
+# relay_client = { path = "../WalletConnectRust/relay_client" }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,12 +3,19 @@ use {
     base64::Engine,
     chrono::{DateTime, Utc},
     ed25519_dalek::Signer,
+    hyper::StatusCode,
     relay_rpc::{
-        auth::did::{DID_DELIMITER, DID_METHOD_KEY, DID_PREFIX},
+        auth::{
+            cacao::CacaoError,
+            did::{DID_DELIMITER, DID_METHOD_KEY, DID_PREFIX},
+        },
         domain::DecodedClientId,
         jwt::{JwtHeader, JWT_HEADER_ALG, JWT_HEADER_TYP},
     },
+    reqwest::Response,
     serde::{de::DeserializeOwned, Deserialize, Serialize},
+    serde_json::Value,
+    url::Url,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,8 +27,6 @@ pub struct SharedClaims {
     /// iss - did:key of an identity key. Enables to resolve attached blockchain
     /// account.
     pub iss: String,
-    /// ksu - key server for identity key verification
-    pub ksu: String,
 }
 
 pub trait GetSharedClaims {
@@ -32,6 +37,8 @@ pub trait GetSharedClaims {
 pub struct SubscriptionRequestAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
+    /// ksu - key server for identity key verification
+    pub ksu: String,
     /// description of action intent. Must be equal to "notify_subscription"
     pub act: String,
     /// did:key of an identity key. Enables to resolve associated Dapp domain
@@ -56,6 +63,8 @@ impl GetSharedClaims for SubscriptionRequestAuth {
 pub struct SubscriptionResponseAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
+    /// ksu - key server for identity key verification
+    pub ksu: String,
     /// description of action intent. Must be equal to
     /// "notify_subscription_response"
     pub act: String,
@@ -78,6 +87,8 @@ impl GetSharedClaims for SubscriptionResponseAuth {
 pub struct SubscriptionUpdateRequestAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
+    /// ksu - key server for identity key verification
+    pub ksu: String,
     /// description of action intent. Must be equal to "notify_update"
     pub act: String,
     /// did:key of an identity key. Enables to resolve associated Dapp domain
@@ -102,6 +113,8 @@ impl GetSharedClaims for SubscriptionUpdateRequestAuth {
 pub struct SubscriptionUpdateResponseAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
+    /// ksu - key server for identity key verification
+    pub ksu: String,
     /// description of action intent. Must be equal to "notify_update_response"
     pub act: String,
     /// did:key of an identity key. Enables to resolve attached blockchain
@@ -123,6 +136,8 @@ impl GetSharedClaims for SubscriptionUpdateResponseAuth {
 pub struct SubscruptionDeleteRequestAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
+    /// ksu - key server for identity key verification
+    pub ksu: String,
     /// description of action intent. Must be equal to "notify_delete"
     pub act: String,
     /// did:key of an identity key. Enables to resolve associated Dapp domain
@@ -144,6 +159,8 @@ impl GetSharedClaims for SubscruptionDeleteRequestAuth {
 pub struct SubscriptionDeleteResponseAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
+    /// ksu - key server for identity key verification
+    pub ksu: String,
     /// description of action intent. Must be equal to "notify_delete_response"
     pub act: String,
     /// did:key of an identity key. Enables to resolve attached blockchain
@@ -177,14 +194,12 @@ pub fn from_jwt<T: DeserializeOwned + GetSharedClaims>(jwt: &str) -> Result<T> {
     let claims = base64::engine::general_purpose::STANDARD_NO_PAD.decode(claims)?;
     let claims = serde_json::from_slice::<T>(&claims)?;
 
-    // TODO call verify_identity (and add keyserver to integration tests)
-
     if claims.get_shared_claims().exp < Utc::now().timestamp().unsigned_abs() {
-        return Err(AuthError::Expired)?;
+        return Err(AuthError::JwtExpired)?;
     }
 
     if claims.get_shared_claims().iat > Utc::now().timestamp_millis().unsigned_abs() {
-        return Err(AuthError::NotYetValid)?;
+        return Err(AuthError::JwtNotYetValid)?;
     }
 
     let mut parts = jwt.rsplitn(2, '.');
@@ -233,19 +248,15 @@ pub fn sign_jwt<T: Serialize>(message: T, identity_keypair: &Keypair) -> Result<
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(serialized)
     };
 
-    let private_key =
-        ed25519_dalek::SecretKey::from_bytes(&hex::decode(identity_keypair.private_key.clone())?)?;
-    let public_key = ed25519_dalek::PublicKey::from(&private_key);
-    let keypair = ed25519_dalek::Keypair {
-        secret: private_key,
-        public: public_key,
-    };
+    let private_key = ed25519_dalek::SigningKey::from_bytes(
+        hex::decode(&identity_keypair.private_key)?[..].try_into()?,
+    );
 
     let message = serde_json::to_string(&message)?;
     let message = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(message);
     let message = format!("{header}.{message}");
-    let signature = keypair.sign(message.as_bytes());
-    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature);
+    let signature = private_key.sign(message.as_bytes());
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes());
 
     Ok(format!("{message}.{signature}"))
 }
@@ -273,44 +284,94 @@ pub enum AuthError {
     #[error("Invalid algorithm")]
     Algorithm,
 
+    #[error("Keyserver returned non-success status code. status:{status} response:{response:?}")]
+    KeyserverUnsuccessfulResponse {
+        status: StatusCode,
+        response: Response,
+    },
+
+    #[error("Keyserver returned non-success response. status:{status} error:{error:?}")]
+    KeyserverNotSuccess {
+        status: String,
+        error: Option<Value>,
+    },
+
+    #[error("Keyserver returned successful response, but without a value")]
+    KeyserverResponseMissingValue,
+
     #[error("Failed to verify with keyserver")]
-    CacaoValidation,
+    CacaoValidation(CacaoError),
 
     #[error("Keyserver account mismatch")]
     CacaoAccountMismatch,
 
-    #[error("Expired")]
-    Expired,
+    #[error("Cacao expired")]
+    CacaoExpired,
 
-    #[error("Not yet valid")]
-    NotYetValid,
+    #[error("Cacao not yet valid")]
+    CacaoNotYetValid,
+
+    #[error("JWT expired")]
+    JwtExpired,
+
+    #[error("JWT not yet valid")]
+    JwtNotYetValid,
 
     #[error("Invalid act")]
     InvalidAct,
 }
 
-// TODO call this
 pub async fn verify_identity(pubkey: &str, keyserver: &str, account: &str) -> Result<()> {
-    let url = format!("{}/identity?publicKey={}", keyserver, pubkey);
-    let res = reqwest::get(&url).await?;
-    let cacao: KeyServerResponse = res.json().await?;
-
-    if cacao.value.is_none() {
-        return Err(AuthError::CacaoValidation)?;
+    let mut url = Url::parse(keyserver)?.join("/identity")?;
+    url.set_query(Some(&format!("publicKey={pubkey}")));
+    let response = reqwest::get(url).await?;
+    if !response.status().is_success() {
+        return Err(AuthError::KeyserverUnsuccessfulResponse {
+            status: response.status(),
+            response,
+        })
+        .map_err(Into::into);
     }
 
-    let cacao = cacao.value.unwrap().cacao;
+    let keyserver_response = response.json::<KeyServerResponse>().await?;
 
-    // TODO verify `iss` signature
+    if keyserver_response.status != "SUCCESS" {
+        Err(AuthError::KeyserverNotSuccess {
+            status: keyserver_response.status,
+            error: keyserver_response.error,
+        })?;
+    }
+
+    let Some(cacao) = keyserver_response.value else {
+        // Keyserver should never do this since it already returned SUCCESS above
+        return Err(AuthError::KeyserverResponseMissingValue)?;
+    };
+    let cacao = cacao.cacao;
+
+    let always_true = cacao.verify().map_err(AuthError::CacaoValidation)?;
+    assert!(always_true);
+
     if cacao.p.iss != account {
         return Err(AuthError::CacaoAccountMismatch)?;
+    }
+
+    // TODO verify `cacao.p.aud`
+
+    // TODO verify `cacao.p.domain`
+
+    if let Some(nbf) = cacao.p.nbf {
+        let nbf = DateTime::parse_from_rfc3339(&nbf)?;
+
+        if Utc::now().timestamp() <= nbf.timestamp() {
+            return Err(AuthError::CacaoNotYetValid)?;
+        }
     }
 
     if let Some(exp) = cacao.p.exp {
         let exp = DateTime::parse_from_rfc3339(&exp)?;
 
-        if exp.timestamp() < Utc::now().timestamp() {
-            return Err(AuthError::CacaoValidation)?;
+        if exp.timestamp() <= Utc::now().timestamp() {
+            return Err(AuthError::CacaoExpired)?;
         }
     }
 
@@ -320,7 +381,7 @@ pub async fn verify_identity(pubkey: &str, keyserver: &str, account: &str) -> Re
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct KeyServerResponse {
     status: String,
-    error: Option<String>,
+    error: Option<Value>,
     value: Option<CacaoValue>,
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -343,7 +343,7 @@ pub async fn verify_identity(pubkey: &str, keyserver: &str, account: &str) -> Re
     }
 
     let Some(cacao) = keyserver_response.value else {
-        // Keyserver should never do this since it already returned SUCCESS above
+        // Keys server should never do this since it already returned SUCCESS above
         return Err(AuthError::KeyserverResponseMissingValue)?;
     };
     let cacao = cacao.cacao;
@@ -352,10 +352,10 @@ pub async fn verify_identity(pubkey: &str, keyserver: &str, account: &str) -> Re
     assert!(always_true);
 
     if cacao.p.iss != account {
-        return Err(AuthError::CacaoAccountMismatch)?;
+        Err(AuthError::CacaoAccountMismatch)?;
     }
 
-    // TODO verify `cacao.p.aud`
+    // TODO verify `cacao.p.aud`. Blocked by at least https://github.com/WalletConnect/walletconnect-utils/issues/128
 
     // TODO verify `cacao.p.domain`
 
@@ -363,7 +363,7 @@ pub async fn verify_identity(pubkey: &str, keyserver: &str, account: &str) -> Re
         let nbf = DateTime::parse_from_rfc3339(&nbf)?;
 
         if Utc::now().timestamp() <= nbf.timestamp() {
-            return Err(AuthError::CacaoNotYetValid)?;
+            Err(AuthError::CacaoNotYetValid)?;
         }
     }
 
@@ -371,7 +371,7 @@ pub async fn verify_identity(pubkey: &str, keyserver: &str, account: &str) -> Re
         let exp = DateTime::parse_from_rfc3339(&exp)?;
 
         if exp.timestamp() <= Utc::now().timestamp() {
-            return Err(AuthError::CacaoExpired)?;
+            Err(AuthError::CacaoExpired)?;
         }
     }
 

--- a/src/handlers/notify.rs
+++ b/src/handlers/notify.rs
@@ -333,20 +333,13 @@ fn sign_message(
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(serialized)
     };
 
-    let private_key = ed25519_dalek::SecretKey::from_bytes(&hex::decode(
-        project_data.identity_keypair.private_key.clone(),
-    )?)?;
-
-    let public_key = ed25519_dalek::PublicKey::from(&private_key);
-
-    let keypair = ed25519_dalek::Keypair {
-        secret: private_key,
-        public: public_key,
-    };
+    let private_key = ed25519_dalek::SigningKey::from_bytes(
+        &hex::decode(project_data.identity_keypair.private_key.clone())?[..].try_into()?,
+    );
 
     let message = format!("{header}.{message}");
-    let signature = keypair.sign(message.as_bytes());
-    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature);
+    let signature = private_key.sign(message.as_bytes());
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes());
 
     Ok(format!("{message}.{signature}"))
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -69,7 +69,7 @@ impl AppState {
 
         let insert_data = ClientData {
             id: client_data.id.clone(),
-            relay_url: url.to_string().trim_end_matches('/').to_string(),
+            relay_url: url.to_string().trim_end_matches('/').to_string(), /* TODO test trim_end_matches('/') */
             sym_key: client_data.sym_key.clone(),
             scope: client_data.scope.clone(),
             ..client_data

--- a/src/websocket_service/handlers/notify_delete.rs
+++ b/src/websocket_service/handlers/notify_delete.rs
@@ -78,8 +78,15 @@ pub async fn handle(
 
     let msg: NotifyMessage<NotifyDelete> = decrypt_message(envelope, &acc.sym_key)?;
 
+    // TODO move above find_one_and_delete()
     let sub_auth = from_jwt::<SubscruptionDeleteRequestAuth>(&msg.params.delete_auth)?;
     let _sub_auth_hash = sha256::digest(msg.params.delete_auth);
+
+    // TODO verify_identity
+
+    // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
+
+    // TODO verify `sub_auth.app` matches `project_data.dapp_url`
 
     if sub_auth.act != "notify_delete" {
         return Err(AuthError::InvalidAct)?;
@@ -117,8 +124,8 @@ pub async fn handle(
             exp: (chrono::Utc::now() + chrono::Duration::seconds(RESPONSE_TTL as i64)).timestamp()
                 as u64,
             iss: format!("did:key:{identity}"),
-            ksu: sub_auth.shared_claims.ksu.clone(),
         },
+        ksu: sub_auth.ksu.clone(),
         aud: sub_auth.shared_claims.iss,
         act: "notify_delete_response".to_string(),
         sub: acc.sub_auth_hash,

--- a/src/websocket_service/handlers/notify_delete.rs
+++ b/src/websocket_service/handlers/notify_delete.rs
@@ -3,6 +3,7 @@ use {
         auth::{
             from_jwt,
             sign_jwt,
+            verify_identity,
             AuthError,
             SharedClaims,
             SubscriptionDeleteResponseAuth,
@@ -82,7 +83,12 @@ pub async fn handle(
     let sub_auth = from_jwt::<SubscruptionDeleteRequestAuth>(&msg.params.delete_auth)?;
     let _sub_auth_hash = sha256::digest(msg.params.delete_auth);
 
-    // TODO verify_identity
+    verify_identity(
+        sub_auth.shared_claims.iss.strip_prefix("did:key:").unwrap(), // TODO remove unwrap()
+        &sub_auth.ksu,
+        &sub_auth.sub,
+    )
+    .await?;
 
     // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 

--- a/src/websocket_service/handlers/notify_update.rs
+++ b/src/websocket_service/handlers/notify_update.rs
@@ -3,6 +3,7 @@ use {
         auth::{
             from_jwt,
             sign_jwt,
+            verify_identity,
             AuthError,
             SharedClaims,
             SubscriptionUpdateRequestAuth,
@@ -71,7 +72,12 @@ pub async fn handle(
     let sub_auth = from_jwt::<SubscriptionUpdateRequestAuth>(&msg.params.update_auth)?;
     let sub_auth_hash = sha256::digest(msg.params.update_auth);
 
-    // TODO verify_identity
+    verify_identity(
+        sub_auth.shared_claims.iss.strip_prefix("did:key:").unwrap(), // TODO remove unwrap()
+        &sub_auth.ksu,
+        &sub_auth.sub,
+    )
+    .await?;
 
     // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 

--- a/src/websocket_service/handlers/notify_update.rs
+++ b/src/websocket_service/handlers/notify_update.rs
@@ -56,7 +56,7 @@ pub async fn handle(
     let client_data = state
         .database
         .collection::<ClientData>(&lookup_data.project_id)
-        .find_one(doc!("_id": lookup_data.account), None)
+        .find_one(doc!("_id": &lookup_data.account), None)
         .await?
         .ok_or(crate::error::Error::NoClientDataForTopic(topic.clone()))?;
 
@@ -71,20 +71,25 @@ pub async fn handle(
     let sub_auth = from_jwt::<SubscriptionUpdateRequestAuth>(&msg.params.update_auth)?;
     let sub_auth_hash = sha256::digest(msg.params.update_auth);
 
+    // TODO verify_identity
+
+    // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
+
+    // TODO verify `sub_auth.app` matches `project_data.dapp_url`
+
     if sub_auth.act != "notify_update" {
         return Err(AuthError::InvalidAct)?;
     }
 
     let response_sym_key = client_data.sym_key.clone();
     let client_data = ClientData {
-        // TODO don't replace this, make sure it matches
-        id: sub_auth.sub.trim_start_matches("did:pkh:").into(),
+        id: sub_auth.sub.strip_prefix("did:pkh:").unwrap().to_owned(), // TODO remove unwrap()
         relay_url: state.config.relay_url.clone(),
         sym_key: client_data.sym_key,
-        scope: sub_auth.scp.split(' ').map(|s| s.into()).collect(),
+        scope: sub_auth.scp.split(' ').map(|s| s.to_owned()).collect(),
         sub_auth_hash: sub_auth_hash.clone(),
         expiry: sub_auth.shared_claims.exp,
-        ksu: sub_auth.shared_claims.ksu.clone(),
+        ksu: sub_auth.ksu.clone(),
     };
     info!("[{request_id}] Updating client: {:?}", &client_data);
 
@@ -109,8 +114,8 @@ pub async fn handle(
             exp: (chrono::Utc::now() + chrono::Duration::seconds(RESPONSE_TTL as i64)).timestamp()
                 as u64,
             iss: format!("did:key:{identity}"),
-            ksu: sub_auth.shared_claims.ksu.clone(),
         },
+        ksu: sub_auth.ksu.clone(),
         aud: sub_auth.shared_claims.iss,
         act: "notify_update_response".to_string(),
         sub: sub_auth_hash,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,17 +1,19 @@
 use {
     base64::Engine,
     chacha20poly1305::{
-        aead::{generic_array::GenericArray, AeadMut},
+        aead::{generic_array::GenericArray, Aead, OsRng},
         ChaCha20Poly1305,
         KeyInit,
     },
     chrono::Utc,
-    ed25519_dalek::Signer,
+    ed25519_dalek::{Signer, SigningKey},
     hyper::StatusCode,
+    lazy_static::lazy_static,
     notify_server::{
         auth::{
             from_jwt,
             AuthError,
+            GetSharedClaims,
             SharedClaims,
             SubscriptionDeleteResponseAuth,
             SubscriptionRequestAuth,
@@ -28,18 +30,27 @@ use {
     },
     rand::{rngs::StdRng, Rng, SeedableRng},
     relay_rpc::{
-        auth::ed25519_dalek::Keypair,
+        auth::{
+            cacao::{self, signature::Eip191},
+            ed25519_dalek::Keypair,
+        },
         domain::{ClientId, DecodedClientId},
         jwt::{JwtHeader, JWT_HEADER_ALG, JWT_HEADER_TYP},
     },
     serde::Serialize,
     serde_json::json,
-    sha2::Sha256,
+    sha2::{Digest, Sha256},
+    sha3::Keccak256,
     std::{sync::Arc, time::Duration},
+    url::Url,
     x25519_dalek::{PublicKey, StaticSecret},
 };
 
 const JWT_LEEWAY: i64 = 30;
+
+lazy_static! {
+    static ref KEYS_SERVER: Url = "https://staging.keys.walletconnect.com".parse().unwrap();
+}
 
 fn urls(env: String) -> (String, String) {
     match env.as_str() {
@@ -63,8 +74,6 @@ fn urls(env: String) -> (String, String) {
     }
 }
 
-const TEST_ACCOUNT: &str = "eip155:123:123456789abcdef";
-
 #[tokio::test]
 async fn notify_properly_sending_message() {
     let env = std::env::var("ENVIRONMENT").unwrap_or("LOCAL".to_owned());
@@ -76,6 +85,19 @@ async fn notify_properly_sending_message() {
     // Generate valid JWT
     let mut rng = StdRng::from_entropy();
     let keypair = Keypair::generate(&mut rng);
+    let signing_key = SigningKey::from_bytes(keypair.secret_key().as_bytes());
+
+    let account_signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
+    let address = &Keccak256::default()
+        .chain_update(
+            &account_signing_key
+                .verifying_key()
+                .to_encoded_point(false)
+                .as_bytes()[1..],
+        )
+        .finalize()[12..];
+    let account = format!("eip155:1:0x{}", hex::encode(address));
+    let did_pkh = format!("did:pkh:{account}");
 
     let seed: [u8; 32] = rng.gen();
 
@@ -134,6 +156,60 @@ async fn notify_properly_sending_message() {
 
     let decoded_client_id = DecodedClientId(*keypair.public_key().as_bytes());
     let client_id = ClientId::from(decoded_client_id);
+    let did_key = format!("did:key:{}", client_id);
+
+    // Register identity key with keys server
+    let mut cacao = cacao::Cacao {
+        h: cacao::header::Header {
+            t: "eip4361".to_owned(),
+        },
+        p: cacao::payload::Payload {
+            domain: format!(
+                "{}{}",
+                KEYS_SERVER.domain().unwrap(),
+                KEYS_SERVER
+                    .port()
+                    .map(|port| format!(":{port}"))
+                    .unwrap_or_else(|| "".to_owned())
+            ),
+            iss: did_pkh.clone(),
+            // Statement necessary because of https://github.com/WalletConnect/WalletConnectRust/issues/42
+            statement: Some("test".to_owned()),
+            aud: KEYS_SERVER.to_string(),
+            version: cacao::Version::V1,
+            nonce: "xxxx".to_owned(), // TODO
+            iat: Utc::now().to_rfc3339(),
+            exp: None,
+            nbf: None,
+            request_id: None,
+            resources: Some(vec![did_key.clone()]),
+        },
+        s: cacao::signature::Signature {
+            t: "".to_owned(),
+            s: "".to_owned(),
+        },
+    };
+    let (signature, recovery): (k256::ecdsa::Signature, _) = account_signing_key
+        .sign_digest_recoverable(Keccak256::new_with_prefix(
+            Eip191.eip191_bytes(&cacao.siwe_message().unwrap()),
+        ))
+        .unwrap();
+    let cacao_signature = [&signature.to_bytes()[..], &[recovery.to_byte()]].concat();
+    cacao.s.t = "eip191".to_owned();
+    cacao.s.s = hex::encode(cacao_signature);
+    cacao.verify().unwrap();
+
+    let response = reqwest::Client::builder()
+        .build()
+        .unwrap()
+        .post(KEYS_SERVER.join("/identity").unwrap())
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&json!({"cacao": cacao})).unwrap())
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    assert!(status.is_success());
 
     // ----------------------------------------------------
     // SUBSCRIBE WALLET CLIENT TO DAPP THROUGHT NOTIFY
@@ -145,10 +221,10 @@ async fn notify_properly_sending_message() {
         shared_claims: SharedClaims {
             iat: Utc::now().timestamp() as u64,
             exp: Utc::now().timestamp() as u64 + 3600,
-            iss: format!("did:key:{}", client_id),
-            ksu: "https://keys.walletconnect.com".to_owned(),
+            iss: did_key.clone(),
         },
-        sub: format!("did:pkh:{TEST_ACCOUNT}"),
+        ksu: KEYS_SERVER.to_string(),
+        sub: did_pkh.clone(),
         aud: format!("did:key:{}", client_id), // TODO should be dapp key not client_id
         scp: "test test1".to_owned(),
         act: "notify_subscription".to_owned(),
@@ -156,7 +232,7 @@ async fn notify_properly_sending_message() {
     };
 
     // Encode the subscription auth
-    let subscription_auth = encode_auth(&subscription_auth, &keypair);
+    let subscription_auth = encode_auth(&subscription_auth, &signing_key);
     let sub_auth_hash = sha256::digest(&*subscription_auth.clone());
 
     let id = chrono::Utc::now().timestamp_millis().unsigned_abs();
@@ -168,7 +244,7 @@ async fn notify_properly_sending_message() {
 
     let response_topic_key = derive_key(dapp_pubkey.to_string(), hex::encode(secret.to_bytes()));
 
-    let mut cipher = ChaCha20Poly1305::new(GenericArray::from_slice(
+    let cipher = ChaCha20Poly1305::new(GenericArray::from_slice(
         &hex::decode(response_topic_key.clone()).unwrap(),
     ));
 
@@ -245,7 +321,7 @@ async fn notify_properly_sending_message() {
 
     let notify_body = json!({
         "notification": notification,
-        "accounts": [TEST_ACCOUNT]
+        "accounts": [account]
     });
 
     // wait for notify server to register the user
@@ -265,7 +341,7 @@ async fn notify_properly_sending_message() {
         panic!("Expected message, got {:?}", resp);
     };
 
-    let mut cipher =
+    let cipher =
         ChaCha20Poly1305::new(GenericArray::from_slice(&hex::decode(&notify_key).unwrap()));
 
     let Envelope::<EnvelopeType0> { iv, sealbox, .. } = Envelope::<EnvelopeType0>::from_bytes(
@@ -294,10 +370,10 @@ async fn notify_properly_sending_message() {
     // TODO: verify issuer
     assert_eq!(claims.msg, notification);
     assert_eq!(claims.sub, sub_auth_hash);
-    assert!(claims.iat < chrono::Utc::now().timestamp() + JWT_LEEWAY);
-    assert!(claims.exp > chrono::Utc::now().timestamp() - JWT_LEEWAY);
+    assert!(claims.iat < chrono::Utc::now().timestamp() + JWT_LEEWAY); // TODO remove leeway
+    assert!(claims.exp > chrono::Utc::now().timestamp() - JWT_LEEWAY); // TODO remove leeway
     assert_eq!(claims.app, "https://my-test-app.com");
-    assert_eq!(claims.aud, format!("did:pkh:{}", TEST_ACCOUNT));
+    assert_eq!(claims.aud, did_pkh);
     assert_eq!(claims.act, "notify_message");
 
     // TODO Notify receipt?
@@ -312,9 +388,9 @@ async fn notify_properly_sending_message() {
             iat: Utc::now().timestamp() as u64,
             exp: Utc::now().timestamp() as u64 + 3600,
             iss: format!("did:key:{}", client_id),
-            ksu: "https://keys.walletconnect.com".to_owned(),
         },
-        sub: format!("did:pkh:{TEST_ACCOUNT}"),
+        ksu: KEYS_SERVER.to_string(),
+        sub: did_pkh.clone(),
         aud: format!("did:key:{}", client_id), // TODO should be dapp key not client_id
         scp: "test test2 test3".to_owned(),
         act: "notify_update".to_owned(),
@@ -322,7 +398,7 @@ async fn notify_properly_sending_message() {
     };
 
     // Encode the subscription auth
-    let update_auth = encode_auth(&update_auth, &keypair);
+    let update_auth = encode_auth(&update_auth, &signing_key);
     let update_auth_hash = sha256::digest(&*update_auth.clone());
 
     let sub_auth = json!({ "updateAuth": update_auth });
@@ -380,8 +456,8 @@ async fn notify_properly_sending_message() {
     // https://github.com/WalletConnect/walletconnect-docs/blob/main/docs/specs/clients/notify/notify-authentication.md#notify-update-response
     // TODO verify issuer
     assert_eq!(claims.sub, update_auth_hash);
-    assert!((claims.shared_claims.iat as i64) < chrono::Utc::now().timestamp() + JWT_LEEWAY);
-    assert!((claims.shared_claims.exp as i64) > chrono::Utc::now().timestamp() - JWT_LEEWAY);
+    assert!((claims.shared_claims.iat as i64) < chrono::Utc::now().timestamp() + JWT_LEEWAY); // TODO remove leeway
+    assert!((claims.shared_claims.exp as i64) > chrono::Utc::now().timestamp() - JWT_LEEWAY); // TODO remove leeway
     assert_eq!(claims.app, "https://my-test-app.com");
     assert_eq!(claims.aud, format!("did:key:{}", client_id));
     assert_eq!(claims.act, "notify_update_response");
@@ -393,16 +469,16 @@ async fn notify_properly_sending_message() {
             iat: Utc::now().timestamp() as u64,
             exp: Utc::now().timestamp() as u64 + 3600,
             iss: format!("did:key:{}", client_id),
-            ksu: "https://keys.walletconnect.com".to_owned(),
         },
-        sub: format!("did:pkh:{TEST_ACCOUNT}"),
+        ksu: KEYS_SERVER.to_string(),
+        sub: did_pkh.clone(),
         aud: format!("did:key:{}", client_id), // TODO should be dapp key not client_id
         act: "notify_delete".to_owned(),
         app: "https://my-test-app.com".to_owned(),
     };
 
     // Encode the subscription auth
-    let delete_auth = encode_auth(&delete_auth, &keypair);
+    let delete_auth = encode_auth(&delete_auth, &signing_key);
     let _delete_auth_hash = sha256::digest(&*delete_auth.clone());
 
     let sub_auth = json!({ "deleteAuth": delete_auth });
@@ -460,8 +536,8 @@ async fn notify_properly_sending_message() {
     // https://github.com/WalletConnect/walletconnect-docs/blob/main/docs/specs/clients/notify/notify-authentication.md#notify-delete-response
     // TODO verify issuer
     assert_eq!(claims.sub, update_auth_hash);
-    assert!((claims.shared_claims.iat as i64) < chrono::Utc::now().timestamp() + JWT_LEEWAY);
-    assert!((claims.shared_claims.exp as i64) > chrono::Utc::now().timestamp() - JWT_LEEWAY);
+    assert!((claims.shared_claims.iat as i64) < chrono::Utc::now().timestamp() + JWT_LEEWAY); // TODO remove leeway
+    assert!((claims.shared_claims.exp as i64) > chrono::Utc::now().timestamp() - JWT_LEEWAY); // TODO remove leeway
     assert_eq!(claims.app, "https://my-test-app.com");
     assert_eq!(claims.aud, format!("did:key:{}", client_id));
     assert_eq!(claims.act, "notify_delete_response");
@@ -483,6 +559,26 @@ async fn notify_properly_sending_message() {
         .unwrap();
 
     assert_eq!(resp.not_found.len(), 1);
+
+    let unregister_auth = UnregisterIdentityRequestAuth {
+        shared_claims: SharedClaims {
+            iat: Utc::now().timestamp() as u64,
+            exp: Utc::now().timestamp() as u64 + 3600,
+            iss: did_key,
+        },
+        pkh: did_pkh,
+        aud: KEYS_SERVER.to_string(),
+        act: "unregister_identity".to_owned(),
+    };
+    let unregister_auth = encode_auth(&unregister_auth, &signing_key);
+    reqwest::Client::builder()
+        .build()
+        .unwrap()
+        .delete(KEYS_SERVER.join("/identity").unwrap())
+        .body(serde_json::to_string(&json!({"idAuth": unregister_auth})).unwrap())
+        .send()
+        .await
+        .unwrap();
 }
 
 fn derive_key(pubkey: String, privkey: String) -> String {
@@ -501,7 +597,7 @@ fn derive_key(pubkey: String, privkey: String) -> String {
     hex::encode(expanded_key)
 }
 
-pub fn encode_auth<T: Serialize>(auth: &T, keypair: &Keypair) -> String {
+pub fn encode_auth<T: Serialize>(auth: &T, signing_key: &SigningKey) -> String {
     let data = JwtHeader {
         typ: JWT_HEADER_TYP,
         alg: JWT_HEADER_ALG,
@@ -516,13 +612,18 @@ pub fn encode_auth<T: Serialize>(auth: &T, keypair: &Keypair) -> String {
 
     let message = format!("{header}.{claims}");
 
-    let signature = keypair.sign(message.as_bytes());
-    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature);
+    let signature = signing_key.sign(message.as_bytes());
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes());
 
     format!("{message}.{signature}")
 }
 
 fn verify_jwt(jwt: &str, key: &str) -> notify_server::error::Result<JwtMessage> {
+    // Refactor to call from_jwt() and then check `iss` with:
+    // let pub_key = did_key.parse::<DecodedClientId>()?;
+    // let key = jsonwebtoken::DecodingKey::from_ed_der(pub_key.as_ref());
+    // Or perhaps do the opposite (i.e. serialize key into iss)
+
     let key = jsonwebtoken::DecodingKey::from_ed_der(&hex::decode(key).unwrap());
 
     let mut parts = jwt.rsplitn(2, '.');
@@ -546,5 +647,23 @@ fn verify_jwt(jwt: &str, key: &str) -> notify_server::error::Result<JwtMessage> 
                 .unwrap(),
         )?),
         Ok(false) | Err(_) => Err(AuthError::InvalidSignature)?,
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UnregisterIdentityRequestAuth {
+    #[serde(flatten)]
+    pub shared_claims: SharedClaims,
+    /// description of action intent. Must be equal to "unregister_identity"
+    pub act: String,
+    /// keyserver URL
+    pub aud: String,
+    /// corresponding blockchain account (did:pkh)
+    pub pkh: String,
+}
+
+impl GetSharedClaims for UnregisterIdentityRequestAuth {
+    fn get_shared_claims(&self) -> &SharedClaims {
+        &self.shared_claims
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -186,8 +186,7 @@ async fn notify_properly_sending_message() {
                     .unwrap_or_else(|| "".to_owned())
             ),
             iss: did_pkh.clone(),
-            // Statement necessary because of https://github.com/WalletConnect/WalletConnectRust/issues/42
-            statement: Some("test".to_owned()),
+            statement: None,
             aud: KEYS_SERVER.to_string(),
             version: cacao::Version::V1,
             nonce: "xxxx".to_owned(), // TODO


### PR DESCRIPTION
# Description

Validates identity keys by retrieving the CACAO object from the keys server.

Also bumped ed25519-dalek to newest major version which required also bumping x25519-dalek. Not sure if this was required as I went down some wrong paths, but better to be on latest version I figure.

Resolves #45 

## How Has This Been Tested?

Locally with integration tests

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
