### PR TITLE
fix: assert one topic per account

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -87,10 +87,11 @@ impl AppState {
         self.database
             .collection::<LookupEntry>("lookup_table")
             .replace_one(
-                // FIXME if topic changes then previous lookup_table entry will be abandoned (e.g.
-                // by second device with same account subscribing)
-                // https://github.com/WalletConnect/notify-server/issues/26
-                doc! { "_id": &topic, "project_id": &project_id.to_string()},
+                doc! {
+                    // Don't query by `_id: topic` to avoid duplicate topics for the same account. See https://github.com/WalletConnect/notify-server/issues/26
+                    "account": client_data.id.clone(),
+                    "project_id": &project_id.to_string(),
+                },
                 LookupEntry {
                     topic: topic.clone(),
                     project_id: project_id.to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,7 +37,8 @@ pub struct ClientData {
     pub scope: HashSet<String>, // TODO rename scope to type?
 }
 
-// TODO purpose of lookup_table is to enable indexing on `topic`, but indexes can be made on any field
+// TODO purpose of lookup_table is to enable indexing on `topic`, but indexes
+// can be made on any field
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LookupEntry {
     #[serde(rename = "_id")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,14 +29,15 @@ pub struct RegisterBody {
 pub struct ClientData {
     #[serde(rename = "_id")]
     pub id: String,
-    pub relay_url: String,
+    pub relay_url: String, // TODO remove this, it's not read anywhere?
     pub sym_key: String,
     pub sub_auth_hash: String,
     pub expiry: u64,
-    pub ksu: String,
-    pub scope: HashSet<String>,
+    pub ksu: String,            // TODO remove?
+    pub scope: HashSet<String>, // TODO rename scope to type?
 }
 
+// TODO purpose of lookup_table is to enable indexing on `topic`, but indexes can be made on any field
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LookupEntry {
     #[serde(rename = "_id")]

--- a/src/websocket_service/handlers/notify_delete.rs
+++ b/src/websocket_service/handlers/notify_delete.rs
@@ -33,6 +33,7 @@ use {
     tracing::{info, warn},
 };
 
+// TODO test idempotency
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,

--- a/src/websocket_service/handlers/notify_subscribe.rs
+++ b/src/websocket_service/handlers/notify_subscribe.rs
@@ -33,6 +33,7 @@ use {
     x25519_dalek::{PublicKey, StaticSecret},
 };
 
+// TODO idempotency
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,

--- a/src/websocket_service/handlers/notify_update.rs
+++ b/src/websocket_service/handlers/notify_update.rs
@@ -31,6 +31,7 @@ use {
     tracing::info,
 };
 
+// TODO test idempotency
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,


### PR DESCRIPTION
# Description

Change query to query by account instead of topic. This updates the existing lookup_table entry with a new topic for an existing account, rather than making a new one for a new topic.

Goal is to prevent multiple topics from being created for the same account.

Resolves #26

## How Has This Been Tested?

Locally with tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
