### PR TITLE
feat: subscribe latency panel

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -55,13 +55,13 @@ dashboard.new(
 .addPanels(layout.generate_grid([
   //////////////////////////////////////////////////////////////////////////////
   row.new('Application'),
-    panels.app.subscribed_project_topics(ds, vars)  { gridPos: pos._2 },
-    panels.app.subscribed_client_topics(ds, vars)   { gridPos: pos._2 },
-    panels.app.dispatched_notifications(ds, vars)   { gridPos: pos._2 },
-    panels.app.send_failed(ds, vars)                { gridPos: pos._2 },
-    panels.app.account_not_found(ds, vars)          { gridPos: pos._2 },
+    panels.app.subscribed_project_topics(ds, vars)  { gridPos: pos._3 },
+    panels.app.subscribed_client_topics(ds, vars)   { gridPos: pos._3 },
+    panels.app.subscribe_latency(ds, vars)          { gridPos: pos._3 },
+    panels.app.dispatched_notifications(ds, vars)   { gridPos: pos._3 },
+    panels.app.send_failed(ds, vars)                { gridPos: pos._3 },
+    panels.app.account_not_found(ds, vars)          { gridPos: pos._3 },
     // TODO send latency (avg & max)
-    // TODO subscribe latency (avg & max)
 
   //////////////////////////////////////////////////////////////////////////////
   row.new('ECS'),

--- a/terraform/monitoring/panels/app/subscribe_latency.libsonnet
+++ b/terraform/monitoring/panels/app/subscribe_latency.libsonnet
@@ -1,0 +1,28 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('ms')
+  .withSoftLimit(
+    axisSoftMin = 0,
+    axisSoftMax = 0.8,
+  );
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Subscribe Latency',
+      datasource  = ds.prometheus,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(rate(subscribe_latency_sum[$__rate_interval])) / sum(rate(subscribe_latency_count[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = 'Latency',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -12,8 +12,9 @@ local docdb_mem_threshold = units.size_bin(GiB = docdb_mem * 0.1);
 
 {
   app: {
-    subscribed_project_topics:  (import 'app/subscribed_project_topics.libsonnet'      ).new,
-    subscribed_client_topics:   (import 'app/subscribed_client_topics.libsonnet'      ).new,
+    subscribed_project_topics:  (import 'app/subscribed_project_topics.libsonnet' ).new,
+    subscribed_client_topics:   (import 'app/subscribed_client_topics.libsonnet'  ).new,
+    subscribe_latency:          (import 'app/subscribe_latency.libsonnet'         ).new,
     dispatched_notifications:   (import 'app/dispatched_notifications.libsonnet'  ).new,
     send_failed:                (import 'app/send_failed.libsonnet'               ).new,
     account_not_found:          (import 'app/account_not_found.libsonnet'         ).new,


### PR DESCRIPTION
# Description

Adds subscribe latency metric to Grafana dashbaord.

Internet seems to say you should use `histogram_quantile()` for this, but I can't seem to figure out how to use that. Seems the problem that that `le=+Inf` on all of the values. But this query seems to do what we want anyway.

Resolves #75

## How Has This Been Tested?

Manually editing prod dashboards

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
