### PR TITLE
fix: adjust location of 4050 check to reduce test flakes

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -325,6 +325,12 @@ async fn notify_properly_sending_message() {
         .await
         .unwrap();
 
+    let msg_4050 = rx.recv().await.unwrap();
+    let RelayClientEvent::Message(msg) = msg_4050 else {
+        panic!("Expected message, got {:?}", msg_4050);
+    };
+    assert_eq!(msg.tag, 4050);
+
     let notification = Notification {
         title: "string".to_owned(),
         body: "string".to_owned(),
@@ -349,7 +355,6 @@ async fn notify_properly_sending_message() {
         .await
         .unwrap();
 
-    let _consume_4050_noop = rx.recv().await.unwrap();
     let resp = rx.recv().await.unwrap();
     let RelayClientEvent::Message(msg) = resp else {
         panic!("Expected message, got {:?}", resp);


### PR DESCRIPTION
# Description

Read 4050 on notify topic before triggering the notification itself. From test log output it seems like the notify_message tag is received before the noop 4050 one is.

I'm not sure still why this would happen, as the 4050 is sent before the subscribe_response is sent, which blocks the test from calling `/notify`. But maybe it has something to do with shared mailboxes as the 4050 is sent before the test subscribes to the topic.

Relevant test failures:
- https://github.com/WalletConnect/notify-server/actions/runs/5940223449/job/16108862783
- https://github.com/WalletConnect/notify-server/actions/runs/5941506682/job/16112951153
- https://github.com/WalletConnect/notify-server/actions/runs/5941506682/job/16113352647

Resolves #77 

## How Has This Been Tested?

Local integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
