### PR TITLE
fix: changing topic didn't work

### DIFF
--- a/src/websocket_service/handlers/notify_subscribe.rs
+++ b/src/websocket_service/handlers/notify_subscribe.rs
@@ -33,7 +33,7 @@ use {
     x25519_dalek::{PublicKey, StaticSecret},
 };
 
-// TODO idempotency
+// TODO test idempotency (create subscriber a second time for the same account)
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,


### PR DESCRIPTION
# Description

Because this function was supposed to be idempotent (called from subscribe) the topic could change. However because topic was _id, _id cannot be changed. Changing from replace to delete & insert avoids changing _id and creating an entirely new record instead.

Resolves #87

## How Has This Been Tested?

Locally with integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
