### PR TITLE
fix: ksu only used for client authentication

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -26,7 +26,7 @@ pub struct SharedClaims {
     /// exp - timestamp when jwt must expire
     pub exp: u64,
     /// iss - did:key of an identity key. Enables to resolve attached blockchain
-    /// account.
+    /// account or Notify Server.
     pub iss: String,
 }
 
@@ -69,8 +69,6 @@ impl GetSharedClaims for SubscriptionRequestAuth {
 pub struct SubscriptionResponseAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
-    /// ksu - key server for identity key verification
-    pub ksu: String,
     /// description of action intent. Must be equal to
     /// "notify_subscription_response"
     pub act: String,
@@ -119,8 +117,6 @@ impl GetSharedClaims for SubscriptionUpdateRequestAuth {
 pub struct SubscriptionUpdateResponseAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
-    /// ksu - key server for identity key verification
-    pub ksu: String,
     /// description of action intent. Must be equal to "notify_update_response"
     pub act: String,
     /// did:key of an identity key. Enables to resolve attached blockchain
@@ -165,8 +161,6 @@ impl GetSharedClaims for SubscruptionDeleteRequestAuth {
 pub struct SubscriptionDeleteResponseAuth {
     #[serde(flatten)]
     pub shared_claims: SharedClaims,
-    /// ksu - key server for identity key verification
-    pub ksu: String,
     /// description of action intent. Must be equal to "notify_delete_response"
     pub act: String,
     /// did:key of an identity key. Enables to resolve attached blockchain

--- a/src/handlers/notify.rs
+++ b/src/handlers/notify.rs
@@ -317,7 +317,6 @@ fn sign_message(
             iat: now.timestamp(),
             exp: add_ttl(now, NOTIFY_MESSAGE_TTL).timestamp(),
             iss: format!("did:key:{identity}"),
-            ksu: client_data.ksu.to_string(),
             aud: format!("did:pkh:{}", client_data.id),
             act: "notify_message".to_string(),
             sub: client_data.sub_auth_hash.clone(),
@@ -356,7 +355,6 @@ pub struct JwtMessage {
     pub exp: i64, // expiry
     // TODO: This was changed from notify pubkey, should be confirmed if we want to keep this
     pub iss: String,       // dapps identity key
-    pub ksu: String,       // key server url
     pub aud: String,       // blockchain account (did:pkh)
     pub act: String,       // action intent (must be "notify_message")
     pub sub: String,       // subscriptionId (sha256 hash of subscriptionAuth)

--- a/src/handlers/subscribe_topic.rs
+++ b/src/handlers/subscribe_topic.rs
@@ -39,7 +39,7 @@ pub async fn handler(
     AuthedProjectId(project_id, _): AuthedProjectId,
     Json(subscribe_topic_data): Json<SubscribeTopicData>,
 ) -> Result<axum::response::Response, crate::error::Error> {
-    info!("Generating keypair for project: {}", project_id);
+    info!("Getting or generating keypair for project: {}", project_id);
     let db = state.database.clone();
 
     if let Some(project_data) = db
@@ -108,6 +108,10 @@ pub async fn handler(
         project_id, signing_public, identity_public, topic
     );
 
+    // FIXME race condition
+    // INSERT INTO project_data (id, keys) VALUES ($ID, $key)
+    // ON CONFLICT (id) DO NOTHING
+    // RETURNING keys;
     db.collection::<ProjectData>("project_data")
         .replace_one(
             doc! { "_id": project_id.clone()},

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,7 +33,6 @@ pub struct ClientData {
     pub sym_key: String,
     pub sub_auth_hash: String,
     pub expiry: u64,
-    pub ksu: String,            // TODO remove?
     pub scope: HashSet<String>, // TODO rename scope to type?
 }
 

--- a/src/websocket_service/handlers/notify_delete.rs
+++ b/src/websocket_service/handlers/notify_delete.rs
@@ -130,7 +130,6 @@ pub async fn handle(
             exp: add_ttl(now, NOTIFY_DELETE_RESPONSE_TTL).timestamp() as u64,
             iss: format!("did:key:{identity}"),
         },
-        ksu: sub_auth.ksu.clone(),
         aud: sub_auth.shared_claims.iss,
         act: "notify_delete_response".to_string(),
         sub: acc.sub_auth_hash,

--- a/src/websocket_service/handlers/notify_subscribe.rs
+++ b/src/websocket_service/handlers/notify_subscribe.rs
@@ -102,7 +102,6 @@ pub async fn handle(
             exp: add_ttl(now, NOTIFY_SUBSCRIBE_RESPONSE_TTL).timestamp() as u64,
             iss: format!("did:key:{identity}"),
         },
-        ksu: sub_auth.ksu.clone(),
         aud: sub_auth.shared_claims.iss,
         act: "notify_subscription_response".to_string(),
         sub: format!("did:key:{identity_public}"),
@@ -138,7 +137,6 @@ pub async fn handle(
         scope: sub_auth.scp.split(' ').map(|s| s.to_owned()).collect(),
         expiry: sub_auth.shared_claims.exp,
         sub_auth_hash,
-        ksu: sub_auth.ksu,
     };
 
     let notify_topic = sha256::digest(&*hex::decode(&notify_key)?);

--- a/src/websocket_service/handlers/notify_update.rs
+++ b/src/websocket_service/handlers/notify_update.rs
@@ -94,7 +94,6 @@ pub async fn handle(
         scope: sub_auth.scp.split(' ').map(|s| s.to_owned()).collect(),
         sub_auth_hash: sub_auth_hash.clone(),
         expiry: sub_auth.shared_claims.exp,
-        ksu: sub_auth.ksu.clone(),
     };
     info!("[{request_id}] Updating client: {:?}", &client_data);
 
@@ -120,7 +119,6 @@ pub async fn handle(
             exp: add_ttl(now, NOTIFY_UPDATE_RESPONSE_TTL).timestamp() as u64,
             iss: format!("did:key:{identity}"),
         },
-        ksu: sub_auth.ksu.clone(),
         aud: sub_auth.shared_claims.iss,
         act: "notify_update_response".to_string(),
         sub: sub_auth_hash,


### PR DESCRIPTION
# Description

As per @llbartekll's [comment](https://github.com/WalletConnect/walletconnect-specs/pull/138#discussion_r1316926452), ksu is only used to authenticate client-sent JWTs.

Resolves #93

## How Has This Been Tested?

Locally with integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
