### PR TITLE
fix(cd): disable alert on math expression

### DIFF
--- a/terraform/monitoring/panels/lb/error_4xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_4xx.libsonnet
@@ -43,10 +43,12 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       value = threshold,
     )
 
-    .setAlert(
-      vars.environment,
-      _alert(vars.namespace, vars.environment, vars.notifications)
-    )
+    // Cannot alert based on math expressions with legacy alerts:
+    // https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries/
+    // .setAlert(
+    //   vars.environment,
+    //   _alert(vars.namespace, vars.environment, vars.notifications)
+    // )
 
     .addTarget(targets.cloudwatch(
       alias       = 'ELB',


### PR DESCRIPTION
# Description

Cannot make alerts based on math expressions in legacy alerting: https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries/

We don't need to alert on 4xx anyways.

Resolves #95

## How Has This Been Tested?

Locally with dev environment

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
