### PR TITLE
fix: follow SIWE spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,7 +3021,7 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=55d74d5#55d74d5c8edaef10e6cacf692febbc56a8970b80"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=54ce4be#54ce4be941e69608885a087046d12da082ef8892"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=55d74d5#55d74d5c8edaef10e6cacf692febbc56a8970b80"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=54ce4be#54ce4be941e69608885a087046d12da082ef8892"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ async-tungstenite = { version = "0.20.0", features = [
 ] }
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "55d74d5", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "55d74d5" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "54ce4be", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "54ce4be" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -177,24 +177,17 @@ async fn notify_properly_sending_message() {
             t: "eip4361".to_owned(),
         },
         p: cacao::payload::Payload {
-            domain: format!(
-                "{}{}",
-                KEYS_SERVER.domain().unwrap(),
-                KEYS_SERVER
-                    .port()
-                    .map(|port| format!(":{port}"))
-                    .unwrap_or_else(|| "".to_owned())
-            ),
+            domain: "app.example.com".to_owned(),
             iss: did_pkh.clone(),
-            statement: None,
-            aud: KEYS_SERVER.to_string(),
+            statement: None, // TODO add statement
+            aud: did_key.clone(),
             version: cacao::Version::V1,
             nonce: "xxxx".to_owned(), // TODO
             iat: Utc::now().to_rfc3339(),
             exp: None,
             nbf: None,
             request_id: None,
-            resources: Some(vec![did_key.clone()]),
+            resources: None, // TODO add identity.walletconnect.com
         },
         s: cacao::signature::Signature {
             t: "".to_owned(),


### PR DESCRIPTION
# Description

Required by https://github.com/WalletConnect/walletconnect-specs/pull/139
The identity key will no longer be in Cacao resources but in the audience.

Resolves #97 

## How Has This Been Tested?

Integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
