### PR TITLE
fix: re-enable Swift integration tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ charset = utf-8
 end_of_line = lf
 indent_size = 2
 indent_style = space
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -1,3 +1,30 @@
+# Secrets
+
+How to set GitHub Actions secrets.
+
+## Notify Server
+
+KEYPAIR_SEED
+Set to a securly random value.
+
+PROJECT_ID
+Project ID for Notify Server to connect to relay. Should have rate limits disabled.
+https://cloud.walletconnect.com/app/project?uuid=5f423bdd-12b2-4544-af6c-8a6ad470e7de
+
+REGISTRY_AUTH_TOKEN
+Registry auth token for prod Notify Server to authenticate project IDs and project secrets for dapps. Get from 1Password.
+
+STAGING_REGISTRY_AUTH_TOKEN
+Registry auth token for staging Notify Server to authenticate project IDs and project secrets for dapps. Get from 1Password.
+
+## Ops
+
+TF_API_TOKEN
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+
+## Notify Integration Tests
+
 TEST_PROJECT_ID
 NOTIFY_PROJECT_SECRET
 https://cloud.walletconnect.com/app/project?uuid=2a4f6cb0-7203-48d1-ba81-c081029cee19
@@ -5,3 +32,16 @@ https://cloud.walletconnect.com/app/project?uuid=2a4f6cb0-7203-48d1-ba81-c081029
 STAGING_TEST_PROJECT_ID
 STAGING_NOTIFY_PROJECT_SECRET
 https://wc-cloud-staging.vercel.app/app/project?uuid=480ef7cc-a55a-451a-b76a-5f12ea28e077
+
+## Swift Integration Tests
+
+SWIFT_INTEGRATION_TESTS_PROJECT_ID
+https://cloud.walletconnect.com/app/project?uuid=fa897f4c-83a0-4f50-bd6b-53a9d94fce63
+
+SWIFT_INTEGRATION_TESTS_DAPP_PROJECT_ID
+SWIFT_INTEGRATION_TESTS_DAPP_PROJECT_SECRET
+https://cloud.walletconnect.com/app/project?uuid=ec020ad1-89bc-4f0f-b7bc-5602990e79b5
+
+SWIFT_INTEGRATION_TESTS_STAGING_DAPP_PROJECT_ID
+SWIFT_INTEGRATION_TESTS_STAGING_DAPP_PROJECT_SECRET
+https://wc-cloud-staging.vercel.app/app/project?uuid=317a4b59-f0db-42e9-bffa-b32caf5f7ddd

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,14 +80,16 @@ jobs:
       test_project_id: ${{ secrets.STAGING_TEST_PROJECT_ID }}
       test_relay_project_id: ${{ secrets.TEST_PROJECT_ID }}
 
-  # TODO: Restore once swift is ready for notify
-  # validate-staging-swift:
-  #   needs: deploy-infra-staging
-  #   uses: ./.github/workflows/validate_swift.yml
-  #   with:
-  #     notify-endpoint: 'staging.notify.walletconnect.com'
-  #     relay-endpoint: 'staging.relay.walletconnect.com'
-
+  validate-staging-swift:
+    needs: deploy-infra-staging
+    uses: ./.github/workflows/validate_swift.yml
+    with:
+      notify-endpoint: 'staging.notify.walletconnect.com'
+      relay-endpoint: 'staging.relay.walletconnect.com'
+    secrets:
+      project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_PROJECT_ID }}
+      dapp_project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_DAPP_STAGING_PROJECT_ID }}
+      dapp_project_secret: ${{ secrets.SWIFT_INTEGRATION_TESTS_DAPP_STAGING_PROJECT_SECRET }}
 
   ##############################################################################
   # Prod
@@ -96,7 +98,7 @@ jobs:
     needs:
       - get-version
       - validate-staging-rust
-    #   - validate-staging-swift
+      - validate-staging-swift
     uses: ./.github/workflows/deploy-infra.yml
     with:
       version: ${{ needs.get-version.outputs.version }}
@@ -122,10 +124,13 @@ jobs:
       test_project_id: ${{ secrets.TEST_PROJECT_ID }}
       test_relay_project_id: ${{ secrets.TEST_PROJECT_ID }}
 
-  # TODO: Restore once swift is ready for notify
-  # validate-swift-prod:
-  #   needs: [deploy-infra-prod]
-  #   uses: ./.github/workflows/validate_swift.yml
-  #   with:
-  #     notify-endpoint: 'notify.walletconnect.com'
-  #     relay-endpoint: 'relay.walletconnect.com'
+  validate-swift-prod:
+    needs: [deploy-infra-prod]
+    uses: ./.github/workflows/validate_swift.yml
+    with:
+      notify-endpoint: 'notify.walletconnect.com'
+      relay-endpoint: 'relay.walletconnect.com'
+    secrets:
+      project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_PROJECT_ID }}
+      dapp_project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_DAPP_PROJECT_ID }}
+      dapp_project_secret: ${{ secrets.SWIFT_INTEGRATION_TESTS_DAPP_PROJECT_SECRET }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,6 +86,7 @@ jobs:
     with:
       notify-endpoint: 'staging.notify.walletconnect.com'
       relay-endpoint: 'staging.relay.walletconnect.com'
+      dapp_domain: 'wc-notify-swift-integration-tests-staging.pages.dev'
     secrets:
       project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_PROJECT_ID }}
       dapp_project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_DAPP_STAGING_PROJECT_ID }}
@@ -130,6 +131,7 @@ jobs:
     with:
       notify-endpoint: 'notify.walletconnect.com'
       relay-endpoint: 'relay.walletconnect.com'
+      dapp_domain: 'wc-notify-swift-integration-tests-prod.pages.dev'
     secrets:
       project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_PROJECT_ID }}
       dapp_project_id: ${{ secrets.SWIFT_INTEGRATION_TESTS_DAPP_PROJECT_ID }}

--- a/.github/workflows/validate_swift.yml
+++ b/.github/workflows/validate_swift.yml
@@ -2,27 +2,10 @@
 name: Validate with Swift
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       relay-endpoint:
         description: 'The endpoint of the relay e.g. relay.walletconnect.com'
-        required: false
-        default: 'staging.relay.walletconnect.com'
-        type: string
-      notify-endpoint:
-        description: 'The endpoint of the notify server e.g. notify.walletconnect.com'
-        required: false
-        default: 'staging.notify.walletconnect.com'
-        type: string
-      swiftBranch:
-        description: 'Swift branch to run on'
-        required: false
-        default: 'main'
-        type: string
-  workflow_call: 
-    inputs: 
-      relay-endpoint: 
-        description: 'The endpoint of the relay e.g. relay.walletconnect.com'
         required: true
         type: string
       notify-endpoint:
@@ -34,10 +17,20 @@ on:
         required: false
         default: 'main'
         type: string
+    secrets:
+      project_id:
+        description: "The project ID to use to use as for the Swift client"
+        required: true
+      dapp_project_id:
+        description: "The project ID to use as the test dapp"
+        required: true
+      dapp_project_secret:
+        description: "The project secret to use for the test dapp"
+        required: true
 
 jobs:
   notify_tests:
-    permissions: 
+    permissions:
       contents: write
     runs-on:
       group: apple-silicon
@@ -53,7 +46,7 @@ jobs:
       with:
         type: 'notify-tests'
         relay-endpoint: ${{ github.event.inputs.relay-endpoint }}
-        project-id: ${{ secrets.PROJECT_ID }}
         notify-endpoint: ${{ github.event.inputs.notify-endpoint }}
-        gm-dapp-project-id: ${{ secrets.GM_DAPP_PROJECT_ID }}
-        gm-dapp-project-secret: ${{ secrets.GM_DAPP_PROJECT_SECRET }} 
+        project-id: ${{ secrets.project_id }}
+        gm-dapp-project-id: ${{ secrets.dapp_project_id }}
+        gm-dapp-project-secret: ${{ secrets.dapp_project_secret }}

--- a/.github/workflows/validate_swift.yml
+++ b/.github/workflows/validate_swift.yml
@@ -17,6 +17,10 @@ on:
         required: false
         default: 'main'
         type: string
+      dapp_domain:
+        description: 'The test dapp domain'
+        required: true
+        type: string
     secrets:
       project_id:
         description: "The project ID to use to use as for the Swift client"
@@ -48,5 +52,6 @@ jobs:
         relay-endpoint: ${{ github.event.inputs.relay-endpoint }}
         notify-endpoint: ${{ github.event.inputs.notify-endpoint }}
         project-id: ${{ secrets.project_id }}
+        gm-dapp-host: ${{ github.event.inputs.dapp_domain }}
         gm-dapp-project-id: ${{ secrets.dapp_project_id }}
         gm-dapp-project-secret: ${{ secrets.dapp_project_secret }}


### PR DESCRIPTION
# Description

Re-enables Swift integration tests. Because staging notify server uses staging registry (instead of prod), I needed to refactor the secrets/inputs so I can use a different secret for staging validation than prod validation.

Resolves #110

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
