### PR TITLE
fix: implementing `retrying_publish` wrapper for the relay client

### DIFF
--- a/src/websocket_service/handlers/mod.rs
+++ b/src/websocket_service/handlers/mod.rs
@@ -1,9 +1,18 @@
 use {
     super::NotifyRequest,
-    crate::{error::Error, types::Envelope},
+    crate::{
+        error::Error,
+        state::AppState,
+        types::Envelope,
+        wsclient::create_connection_opts,
+        Result,
+    },
     chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit},
+    relay_rpc::domain::Topic,
     serde::de::DeserializeOwned,
     sha2::digest::generic_array::GenericArray,
+    std::time::Duration,
+    tracing::{error, warn},
 };
 
 pub mod notify_delete;
@@ -25,4 +34,38 @@ fn decrypt_message<T: DeserializeOwned, E>(
         .map_err(|_| crate::error::Error::EncryptionError("Failed to decrypt".into()))?;
 
     serde_json::from_slice::<NotifyRequest<T>>(&msg).map_err(Error::SerdeJson)
+}
+
+async fn retrying_publish(
+    state: &AppState,
+    client: &relay_client::websocket::Client,
+    topic: Topic,
+    message: &str,
+    tag: u32,
+    ttl: Duration,
+    prompt: bool,
+) -> Result<()> {
+    if let Err(e) = client
+        .publish(topic.clone(), message, tag, ttl, prompt)
+        .await
+    {
+        warn!("Reconnecting after an error in publishing message: {}", e);
+        while let Err(e) = client
+            .connect(&create_connection_opts(
+                &state.config.relay_url,
+                &state.config.project_id,
+                &state.keypair,
+                &state.config.notify_url,
+            )?)
+            .await
+        {
+            error!("Error reconnecting to relay: {}", e);
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+        if let Err(e) = client.publish(topic, message, tag, ttl, prompt).await {
+            error!("Error on publishing after reconnect, giving up: {}", e);
+            return Err(Error::RelayClientStopped);
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
# Description

This PR introduces [retrying_publish](https://github.com/WalletConnect/notify-server/pull/124/files#diff-dbcb49eea8de7203d348b32db156923a8d71e563c9af3e11e9594f69037ee03fR39) function which wraps the current relay client `.publish` method and adds additional retrying and client reconnection logic to the current publishing mechanism:


- Checking if there is an error when publishing a message,
- Trying to reconnect with the 1-second retry interval in a loop,
- After successfully reconnection trying to re-publish the message,
- Give up when the publish errors after reconnecting.

The `client.publish` is replaced with the new function in websocket message handlers.


Resolves #74

## How Has This Been Tested?

It should be tested by the current integration testing because the new function replaces the `.publish` which is indirectly used in the tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
