### PR TITLE
fix: handle relay events in parallel

### DIFF
--- a/src/websocket_service/handlers/notify_subscribe.rs
+++ b/src/websocket_service/handlers/notify_subscribe.rs
@@ -33,17 +33,17 @@ use {
     relay_rpc::domain::DecodedClientId,
     serde_json::{json, Value},
     std::{sync::Arc, time::Duration},
-    tracing::info,
+    tracing::{info, instrument},
     x25519_dalek::StaticSecret,
 };
 
 // TODO test idempotency (create subscriber a second time for the same account)
+#[instrument(name = "wc_notifySubscribe", skip_all)]
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,
     client: &Arc<relay_client::websocket::Client>,
 ) -> Result<()> {
-    let _span = tracing::info_span!("wc_notifySubscribe").entered();
     let topic = msg.topic.to_string();
 
     // Grab record from db

--- a/src/websocket_service/handlers/notify_watch_subscriptions.rs
+++ b/src/websocket_service/handlers/notify_watch_subscriptions.rs
@@ -48,16 +48,15 @@ use {
     relay_rpc::domain::{DecodedClientId, Topic},
     serde_json::{json, Value},
     std::sync::Arc,
-    tracing::info,
+    tracing::{info, instrument},
 };
 
+#[instrument(name = "wc_notifyWatchSubscriptions", skip_all)]
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,
     client: &Arc<relay_client::websocket::Client>,
 ) -> Result<()> {
-    let _span = tracing::info_span!("wc_notifyWatchSubscriptions").entered();
-
     if msg.topic != state.notify_keys.key_agreement_topic {
         return Err(Error::WrongNotifyWatchSubscriptionsTopic(msg.topic));
     }
@@ -186,16 +185,12 @@ pub async fn handle(
     Ok(())
 }
 
+#[instrument(skip(database))]
 pub async fn collect_subscriptions(
     account: &str,
     app_domain: Option<&str>,
     database: &Database,
 ) -> Result<Vec<NotifyServerSubscription>> {
-    let _span = tracing::info_span!(
-        "collect_subscriptions", account = %account, app_domain = ?app_domain,
-    )
-    .entered();
-
     info!("Called collect_subscriptions");
 
     let mut lookup_data = database
@@ -249,6 +244,7 @@ pub async fn collect_subscriptions(
 }
 
 // TODO do async outside of websocket request handler
+#[instrument(skip_all, fields(account = %account, app_domain = %app_domain))]
 pub async fn update_subscription_watchers(
     account: &str,
     app_domain: &str,
@@ -257,11 +253,6 @@ pub async fn update_subscription_watchers(
     authentication_secret: &ed25519_dalek::SigningKey,
     authentication_public: &ed25519_dalek::VerifyingKey,
 ) -> Result<()> {
-    let _span = tracing::info_span!(
-        "update_subscription_watchers", account = %account, app_domain = ?app_domain,
-    )
-    .entered();
-
     info!("Called update_subscription_watchers");
 
     let identity: DecodedClientId = DecodedClientId(authentication_public.to_bytes());
@@ -269,6 +260,7 @@ pub async fn update_subscription_watchers(
 
     let did_pkh = format!("did:pkh:{account}");
 
+    #[instrument(skip_all, fields(did_pkh = %did_pkh, aud = %aud, subscriptions_count = %subscriptions.len()))]
     async fn send(
         subscriptions: Vec<NotifyServerSubscription>,
         aud: String,
@@ -278,8 +270,6 @@ pub async fn update_subscription_watchers(
         client: &relay_client::websocket::Client,
         authentication_secret: &ed25519_dalek::SigningKey,
     ) -> Result<()> {
-        let _span = tracing::info_span!("sending wc_notifySubscriptionsChanged", did_pkh = %did_pkh, aud = %aud, subscriptions_count = subscriptions.len()).entered();
-
         let now = Utc::now();
         let response_message = WatchSubscriptionsChangedRequestAuth {
             shared_claims: SharedClaims {


### PR DESCRIPTION
# Description

Handles relay events in parallel, fixing the disconnect issue >95% of the time.

Needed to change from spans to instrument because spans are not async-safe.

Resolves #126

## How Has This Been Tested?

Locally with integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
