### PR TITLE
fix: implement relay websocket connection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## v0.15.1 - 2023-10-17
+#### Bug Fixes
+- relay websocket connection state implementation - (a0bf2f2) - Max Kalashnikoff
+
+- - -
+
 ## v0.14.2 - 2023-10-17
 #### Bug Fixes
 - Terraform workspace in CI - (2d43c97) - Xavier Basty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,7 @@ checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "notify-server"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-server"
-version = "0.14.1"
+version = "0.15.1"
 edition = "2021"
 authors = ["Maciej Rak <raku@walletconnect.com>"]
 build = "build.rs"


### PR DESCRIPTION
# Description

This PR introduces the following changes:
- [WebSocketClientState](https://github.com/WalletConnect/notify-server/pull/128/commits/a0bf2f27bc6860b1c0d4015e19e716be140a6db4#diff-963b8df3c04dcb31e2832a139b77e2838822bc945753475a04e93fbf0b54abcfR46) enum for tracking the websocket connection state.
  - The `Connecting` state includes a tokio notifier to notify waiting for the connection/reconnection threads.
- [respawn_connection](https://github.com/WalletConnect/notify-server/pull/128/commits/a0bf2f27bc6860b1c0d4015e19e716be140a6db4#diff-963b8df3c04dcb31e2832a139b77e2838822bc945753475a04e93fbf0b54abcfR121) function that connects to the WebSocket and changes the connection state.
- [publish_message](https://github.com/WalletConnect/notify-server/pull/128/commits/a0bf2f27bc6860b1c0d4015e19e716be140a6db4#diff-963b8df3c04dcb31e2832a139b77e2838822bc945753475a04e93fbf0b54abcfR161) relay client publish function wrapper that tracks a connection state and spawns a reconnection in case of an error during the publish call.
- Replacing old functions with the new wrappers and passing down additional parameters.

Resolves #74 

## How Has This Been Tested?

The concept was tested [by the simple isolated code](https://gist.github.com/geekbrother/35cd5fee2bc333c2e49af680c0136f25), and implementation was tested using the unit and integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
