### PR TITLE
fix: only release on master branch & fix bumping of Cargo.lock version

### DIFF
--- a/.github/workflows/event_release.yaml
+++ b/.github/workflows/event_release.yaml
@@ -3,6 +3,8 @@ run-name: 'Release / ${{ github.event.head_commit.message }}'
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - '.github/**'
       - 'docs/**'

--- a/.github/workflows/event_release.yaml
+++ b/.github/workflows/event_release.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.1.4
+        uses: WalletConnect/actions/github/update-rust-version/@2.1.5
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:

--- a/cog.toml
+++ b/cog.toml
@@ -1,5 +1,0 @@
-pre_bump_hooks = [
-    "cargo check",
-]
-
-tag_prefix = "v"


### PR DESCRIPTION
# Description

- Only release on the master branch.
- Also update to latest version of WalletConnect/actions/github/update-rust-version which fixes the version bumping of `Cargo.lock`.
- Also remove cog.toml as this was causing a custom tag prefix to be set with `v` which was incompatible with the expectations of the rest of the CD pipeline

Resolves #129

## How Has This Been Tested?

In my other PR: https://github.com/WalletConnect/notify-server/pull/113/files#diff-c279c2a7a9203ec91966935663601dd38282ad4239056808ad81e596ee606a3e

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
