### PR TITLE
chore: changing threshold for 5xx alerting rule

### DIFF
--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -4,7 +4,7 @@ local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
 local panels    = grafana.panels;
 local targets   = grafana.targets;
 
-local threshold = 100;
+local threshold = 1;
 
 local _configuration = defaults.configuration.timeseries
   .withSoftLimit(
@@ -20,7 +20,7 @@ local _configuration = defaults.configuration.timeseries
 local _alert(namespace, env, notifications) = grafana.alert.new(
   namespace     = namespace,
   name          = "%(env)s - 5XX alert"     % { env: grafana.utils.strings.capitalize(env) },
-  message       = '%(env)s - Too many 5XX'  % { env: grafana.utils.strings.capitalize(env) },
+  message       = '%(env)s - Notify - 5XX alert'  % { env: grafana.utils.strings.capitalize(env) },
   notifications = notifications,
   noDataState   = 'no_data',
   conditions    = [


### PR DESCRIPTION
# Description

We have an alerting rule for 5xx with a threshold of 100 in Grafana.
To catch every 5xx and not wait until it grows so much it changed to 1.
The alert message is changed to reflect threshold changes.

Resolves #139 

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
