### PR TITLE
fix: change `publish` to use http relay client in handlers

### DIFF
--- a/src/websocket_service/handlers/notify_delete.rs
+++ b/src/websocket_service/handlers/notify_delete.rs
@@ -142,7 +142,8 @@ pub async fn handle(
 
     let response_topic = sha256::digest(&sym_key);
 
-    client
+    state
+        .http_relay_client
         .publish(
             response_topic.into(),
             base64_notification,
@@ -156,7 +157,7 @@ pub async fn handle(
         account.clone(),
         &project.app_domain,
         &state.postgres,
-        client.as_ref(),
+        &state.http_relay_client.clone(),
         &state.notify_keys.authentication_secret,
         &state.notify_keys.authentication_public,
     )

--- a/src/websocket_service/handlers/notify_subscribe.rs
+++ b/src/websocket_service/handlers/notify_subscribe.rs
@@ -31,7 +31,6 @@ use {
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,
-    client: &Arc<relay_client::websocket::Client>,
 ) -> Result<()> {
     let topic = msg.topic;
 
@@ -172,12 +171,14 @@ pub async fn handle(
 
     // Send noop to extend ttl of relay's mapping
     info!("publishing noop to notify_topic: {notify_topic}");
-    client
+    state
+        .http_relay_client
         .publish(notify_topic, "", 4050, Duration::from_secs(300), false)
         .await?;
 
     info!("publishing subscribe response to topic: {response_topic}");
-    client
+    state
+        .http_relay_client
         .publish(
             response_topic.into(),
             base64_notification,
@@ -191,7 +192,7 @@ pub async fn handle(
         account,
         &project.app_domain,
         &state.postgres,
-        client.as_ref(),
+        &state.http_relay_client.clone(),
         &state.notify_keys.authentication_secret,
         &state.notify_keys.authentication_public,
     )

--- a/src/websocket_service/handlers/notify_update.rs
+++ b/src/websocket_service/handlers/notify_update.rs
@@ -27,7 +27,6 @@ use {
 pub async fn handle(
     msg: relay_client::websocket::PublishedMessage,
     state: &Arc<AppState>,
-    client: &Arc<relay_client::websocket::Client>,
 ) -> Result<()> {
     let topic = msg.topic;
 
@@ -138,7 +137,8 @@ pub async fn handle(
 
     let response_topic = sha256::digest(&sym_key);
 
-    client
+    state
+        .http_relay_client
         .publish(
             response_topic.into(),
             base64_notification,
@@ -152,7 +152,7 @@ pub async fn handle(
         account,
         &project.app_domain,
         &state.postgres,
-        client.as_ref(),
+        &state.http_relay_client.clone(),
         &state.notify_keys.authentication_secret,
         &state.notify_keys.authentication_public,
     )

--- a/src/websocket_service/mod.rs
+++ b/src/websocket_service/mod.rs
@@ -131,21 +131,21 @@ async fn handle_msg(
         }
         NOTIFY_SUBSCRIBE_TAG => {
             info!("Received notify subscribe on topic {topic}");
-            if let Err(e) = notify_subscribe::handle(msg, state, client).await {
+            if let Err(e) = notify_subscribe::handle(msg, state).await {
                 warn!("Error handling notify subscribe: {e}");
             }
             info!("Finished processing notify subscribe on topic {topic}");
         }
         NOTIFY_UPDATE_TAG => {
             info!("Received notify update on topic {topic}");
-            if let Err(e) = notify_update::handle(msg, state, client).await {
+            if let Err(e) = notify_update::handle(msg, state).await {
                 warn!("Error handling notify update: {e}");
             }
             info!("Finished processing notify update on topic {topic}");
         }
         NOTIFY_WATCH_SUBSCRIPTIONS_TAG => {
             info!("Received notify watch subscriptions on topic {topic}");
-            if let Err(e) = notify_watch_subscriptions::handle(msg, state, client).await {
+            if let Err(e) = notify_watch_subscriptions::handle(msg, state).await {
                 warn!("Error handling notify watch subscriptions: {e}");
             }
             info!("Finished processing notify watch subscriptions on topic {topic}");


### PR DESCRIPTION
# Description

This PR changes the use of `publish` from websocket client to the [HTTP relay client](https://github.com/WalletConnect/WalletConnectRust/blob/main/relay_client/src/http.rs) to solve the websocket disconnect issue.

Resolves #74

## How Has This Been Tested?

Integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
