### PR TITLE
fix: robust migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,9 +98,9 @@ rmp-serde = "1.1.1"
 deadpool-redis = "0.12.0"
 rand_chacha = "0.3.1"
 sqlx = { version = "0.7.1", features = ["runtime-tokio-native-tls", "postgres", "chrono", "uuid"] }
+sha3 = "0.10.8"
 
 [dev-dependencies]
-sha3 = "0.10.8"
 k256 = "0.13.1"
 test-context = "0.1"
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -77,32 +77,41 @@ pub async fn migrate(mongo: &mongodb::Database, postgres: &sqlx::PgPool) -> Resu
 
     while lookup_entry_cursor.advance().await? {
         let lookup_entry = lookup_entry_cursor.deserialize_current()?;
-        let client_data = mongo
+        if let Some(client_data) = mongo
             .collection::<ClientData>(&lookup_entry.project_id)
             .find_one(doc! {"_id": lookup_entry.account.clone()}, None)
             .await?
-            .unwrap();
+        {
+            match get_project_by_project_id(lookup_entry.project_id.clone().into(), postgres).await
+            {
+                Ok(project) => {
+                    upsert_subscriber(
+                        project.id,
+                        client_data.id.into(),
+                        client_data.scope,
+                        &hex::decode(&client_data.sym_key)?.try_into().unwrap(),
+                        lookup_entry.topic.clone().into(),
+                        postgres,
+                    )
+                    .await?;
+                }
+                Err(sqlx::Error::RowNotFound) => {
+                    // no-op
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
 
-        let project =
-            get_project_by_project_id(lookup_entry.project_id.clone().into(), postgres).await?;
-
-        upsert_subscriber(
-            project.id,
-            client_data.id.into(),
-            client_data.scope,
-            &hex::decode(&client_data.sym_key)?.try_into().unwrap(),
-            lookup_entry.topic.clone().into(),
-            postgres,
-        )
-        .await?;
+            mongo
+                .collection::<ClientData>(&lookup_entry.project_id)
+                .delete_one(doc! {"_id": lookup_entry.account}, None)
+                .await?;
+        }
 
         mongo
             .collection::<LookupEntry>("lookup_table")
             .delete_one(doc! {"_id": lookup_entry.topic}, None)
-            .await?;
-        mongo
-            .collection::<ClientData>(&lookup_entry.project_id)
-            .delete_one(doc! {"_id": lookup_entry.account}, None)
             .await?;
     }
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -85,12 +85,13 @@ pub async fn migrate(mongo: &mongodb::Database, postgres: &sqlx::PgPool) -> Resu
             match get_project_by_project_id(lookup_entry.project_id.clone().into(), postgres).await
             {
                 Ok(project) => {
+                    let notify_key = hex::decode(&client_data.sym_key)?.try_into().unwrap();
                     upsert_subscriber(
                         project.id,
                         client_data.id.into(),
                         client_data.scope,
-                        &hex::decode(&client_data.sym_key)?.try_into().unwrap(),
-                        lookup_entry.topic.clone().into(),
+                        &notify_key,
+                        sha256::digest(&notify_key).into(),
                         postgres,
                     )
                     .await?;

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -14,9 +14,20 @@ use {
 new_type!(
     #[doc = "Represents a CAIP-10 account ID."]
     #[as_ref(forward)]
-    #[from(forward)]
     AccountId: Arc<str>
 );
+
+impl From<String> for AccountId {
+    fn from(s: String) -> Self {
+        Self(Arc::from(s.to_ascii_lowercase()))
+    }
+}
+
+impl From<&str> for AccountId {
+    fn from(s: &str) -> Self {
+        Self(Arc::from(s.to_ascii_lowercase()))
+    }
+}
 
 #[derive(Debug, FromRow)]
 pub struct Project {

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -56,33 +56,24 @@ mod test {
         // https://github.com/ChainAgnostic/namespaces/blob/main/eip155/caip10.md#test-cases
 
         // Ethereum mainnet (valid/checksummed)
-        let ethereum_mainnet_valid = "eip155:1:0x22227A31dd842196A246d8f3b775998560eAa61d";
-        assert_eq!(
-            ethereum_mainnet_valid,
-            ensure_erc_55(ethereum_mainnet_valid)
-        );
+        let test = "eip155:1:0x22227A31dd842196A246d8f3b775998560eAa61d";
+        assert_eq!(test, ensure_erc_55(test));
 
         // Ethereum mainnet (will not validate in EIP155-conformant systems)
-        let ethereum_mainnet_not_valid = "eip155:1:0x22227a31dd842196a246d8f3b775998560eaa61d";
-        assert_ne!(
-            ethereum_mainnet_not_valid,
-            ensure_erc_55(ethereum_mainnet_not_valid)
-        );
+        let test = "eip155:1:0x22227a31dd842196a246d8f3b775998560eaa61d";
+        assert_ne!(test, ensure_erc_55(test));
 
         // Polygon mainnet (valid/checksummed)
-        let polygon_mainnet_valid = "eip155:137:0x0495766cD136138Fc492Dd499B8DC87A92D6685b";
-        assert_eq!(polygon_mainnet_valid, ensure_erc_55(polygon_mainnet_valid));
+        let test = "eip155:137:0x0495766cD136138Fc492Dd499B8DC87A92D6685b";
+        assert_eq!(test, ensure_erc_55(test));
 
         // Polygon mainnet (will not validate in EIP155-conformant systems)
-        let polygon_mainnet_not_valid = "eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B";
-        assert_ne!(
-            polygon_mainnet_not_valid,
-            ensure_erc_55(polygon_mainnet_not_valid)
-        );
+        let test = "eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B";
+        assert_ne!(test, ensure_erc_55(test));
 
         // Not EIP155
-        let random = "jkF53jF";
-        assert_eq!(random, ensure_erc_55(random));
+        let junk = "jkF53jF";
+        assert_eq!(junk, ensure_erc_55(junk));
     }
 
     #[test]

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -1,7 +1,7 @@
 use {relay_rpc::new_type, sha2::Digest, sha3::Keccak256, std::sync::Arc};
 
 new_type!(
-    #[doc = "A CAIP-10 account ID which is guaranteed to be lowercase to avoid ERC-55 duplicates."]
+    #[doc = "A CAIP-10 account ID."]
     #[as_ref(forward)]
     AccountId: Arc<str>
 );
@@ -20,9 +20,9 @@ impl From<&str> for AccountId {
 
 fn ensure_erc_55(s: &str) -> String {
     if s.starts_with("eip155:") {
-        let zerox = "0x";
-        if let Some(zerox_start) = s.find(zerox) {
-            let hex_start = zerox_start + zerox.len();
+        let ox = "0x";
+        if let Some(ox_start) = s.find(ox) {
+            let hex_start = ox_start + ox.len();
             s[0..hex_start]
                 .chars()
                 .chain(erc_55_checksum_encode(&s[hex_start..].to_ascii_lowercase()))
@@ -82,10 +82,13 @@ mod test {
         // https://eips.ethereum.org/EIPS/eip-55
 
         fn test(addr: &str) {
+            let ox = "0x";
             assert_eq!(
                 addr,
-                "0x".chars()
-                    .chain(erc_55_checksum_encode(&addr[2..].to_ascii_lowercase()))
+                ox.chars()
+                    .chain(erc_55_checksum_encode(
+                        &addr[ox.len()..].to_ascii_lowercase()
+                    ))
                     .collect::<String>()
             );
         }

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -1,0 +1,19 @@
+use {relay_rpc::new_type, std::sync::Arc};
+
+new_type!(
+    #[doc = "A CAIP-10 account ID which is guaranteed to be lowercase to avoid ERC-55 duplicates."]
+    #[as_ref(forward)]
+    AccountId: Arc<str>
+);
+
+impl From<String> for AccountId {
+    fn from(s: String) -> Self {
+        Self(Arc::from(s.to_ascii_lowercase()))
+    }
+}
+
+impl From<&str> for AccountId {
+    fn from(s: &str) -> Self {
+        Self(Arc::from(s.to_ascii_lowercase()))
+    }
+}

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -20,12 +20,16 @@ impl From<&str> for AccountId {
 
 fn ensure_erc_55(s: &str) -> String {
     if s.starts_with("eip155:") {
-        // If no 0x then address is very invalid anyway. Not validating this for now, goal is just to avoid duplicates.
-        let hex_start = s.find("0x").map(|x| x + 2).unwrap_or(s.len());
-        s[0..hex_start]
-            .chars()
-            .chain(erc_55_checksum_encode(&s[hex_start..].to_ascii_lowercase()))
-            .collect()
+        if let Some(zerox_start) = s.find("0x") {
+            let hex_start = zerox_start + 2;
+            s[0..hex_start]
+                .chars()
+                .chain(erc_55_checksum_encode(&s[hex_start..].to_ascii_lowercase()))
+                .collect()
+        } else {
+            // If no 0x then address is very invalid anyway. Not validating this for now, goal is just to avoid duplicates.
+            s.to_owned()
+        }
     } else {
         s.to_owned()
     }

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -20,8 +20,9 @@ impl From<&str> for AccountId {
 
 fn ensure_erc_55(s: &str) -> String {
     if s.starts_with("eip155:") {
-        if let Some(zerox_start) = s.find("0x") {
-            let hex_start = zerox_start + 2;
+        let zerox = "0x";
+        if let Some(zerox_start) = s.find(zerox) {
+            let hex_start = zerox_start + zerox.len();
             s[0..hex_start]
                 .chars()
                 .chain(erc_55_checksum_encode(&s[hex_start..].to_ascii_lowercase()))

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -1,4 +1,4 @@
-use {relay_rpc::new_type, std::sync::Arc};
+use {relay_rpc::new_type, sha2::Digest, sha3::Keccak256, std::sync::Arc};
 
 new_type!(
     #[doc = "A CAIP-10 account ID which is guaranteed to be lowercase to avoid ERC-55 duplicates."]
@@ -8,12 +8,97 @@ new_type!(
 
 impl From<String> for AccountId {
     fn from(s: String) -> Self {
-        Self(Arc::from(s.to_ascii_lowercase()))
+        Self::from(s.as_ref())
     }
 }
 
 impl From<&str> for AccountId {
     fn from(s: &str) -> Self {
-        Self(Arc::from(s.to_ascii_lowercase()))
+        Self(Arc::from(ensure_erc_55(s)))
+    }
+}
+
+fn ensure_erc_55(s: &str) -> String {
+    if s.starts_with("eip155:") {
+        // If no 0x then address is very invalid anyway. Not validating this for now, goal is just to avoid duplicates.
+        let hex_start = s.find("0x").map(|x| x + 2).unwrap_or(s.len());
+        format!(
+            "{}{}",
+            &s[0..hex_start],
+            erc_55_checksum_encode(&s[hex_start..].to_ascii_lowercase())
+        )
+    } else {
+        s.to_owned()
+    }
+}
+
+fn erc_55_checksum_encode(s: &str) -> String {
+    let address_hash = hex::encode(
+        Keccak256::default()
+            .chain_update(s.to_ascii_lowercase())
+            .finalize(),
+    );
+    s.chars()
+        .enumerate()
+        .map(|(i, c)| {
+            if !c.is_numeric() && address_hash.as_bytes()[i] > b'7' {
+                c.to_ascii_uppercase()
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_eip155() {
+        // https://github.com/ChainAgnostic/namespaces/blob/main/eip155/caip10.md#test-cases
+
+        // Ethereum mainnet (valid/checksummed)
+        let ethereum_mainnet_valid = "eip155:1:0x22227A31dd842196A246d8f3b775998560eAa61d";
+        assert_eq!(
+            ethereum_mainnet_valid,
+            ensure_erc_55(ethereum_mainnet_valid)
+        );
+
+        // Ethereum mainnet (will not validate in EIP155-conformant systems)
+        let ethereum_mainnet_not_valid = "eip155:1:0x22227a31dd842196a246d8f3b775998560eaa61d";
+        assert_ne!(
+            ethereum_mainnet_not_valid,
+            ensure_erc_55(ethereum_mainnet_not_valid)
+        );
+
+        // Polygon mainnet (valid/checksummed)
+        let polygon_mainnet_valid = "eip155:137:0x0495766cD136138Fc492Dd499B8DC87A92D6685b";
+        assert_eq!(polygon_mainnet_valid, ensure_erc_55(polygon_mainnet_valid));
+
+        // Polygon mainnet (will not validate in EIP155-conformant systems)
+        let polygon_mainnet_not_valid = "eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B";
+        assert_ne!(
+            polygon_mainnet_not_valid,
+            ensure_erc_55(polygon_mainnet_not_valid)
+        );
+
+        // Not EIP155
+        let random = "jkF53jF";
+        assert_eq!(random, ensure_erc_55(random));
+    }
+
+    #[test]
+    fn test_erc_55() {
+        // https://eips.ethereum.org/EIPS/eip-55
+
+        fn test(addr: &str) {
+            assert_eq!(addr, format!("0x{}", erc_55_checksum_encode(&addr[2..])));
+        }
+
+        test("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+        test("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359");
+        test("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB");
+        test("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb");
     }
 }

--- a/src/model/types/mod.rs
+++ b/src/model/types/mod.rs
@@ -1,33 +1,14 @@
 use {
     chrono::{DateTime, Utc},
-    relay_rpc::{
-        domain::{ProjectId, Topic},
-        new_type,
-    },
+    relay_rpc::domain::{ProjectId, Topic},
     sqlx::FromRow,
-    std::sync::Arc,
     uuid::Uuid,
 };
 
 // See /migrations/ERD.md
 
-new_type!(
-    #[doc = "Represents a CAIP-10 account ID."]
-    #[as_ref(forward)]
-    AccountId: Arc<str>
-);
-
-impl From<String> for AccountId {
-    fn from(s: String) -> Self {
-        Self(Arc::from(s.to_ascii_lowercase()))
-    }
-}
-
-impl From<&str> for AccountId {
-    fn from(s: &str) -> Self {
-        Self(Arc::from(s.to_ascii_lowercase()))
-    }
-}
+mod account_id;
+pub use account_id::*;
 
 #[derive(Debug, FromRow)]
 pub struct Project {

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1421,7 +1421,8 @@ async fn test_account_case_insensitive() {
         .await
         .unwrap();
 
-    let account: AccountId = "eip155:1:0xFFF".into();
+    let addr_prefix = "eip155:1:0x";
+    let account: AccountId = format!("{addr_prefix}fff").into();
     let scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let notify_key = rand::Rng::gen::<[u8; 32]>(&mut rand::thread_rng());
     let notify_topic = sha256::digest(&notify_key).into();
@@ -1436,9 +1437,8 @@ async fn test_account_case_insensitive() {
     .await
     .unwrap();
 
-    let subscribers =
-        get_subscriptions_by_account(account.into_value().to_uppercase().into(), &postgres)
-            .await
-            .unwrap();
+    let subscribers = get_subscriptions_by_account(format!("{addr_prefix}FFF").into(), &postgres)
+        .await
+        .unwrap();
     assert_eq!(subscribers.len(), 1);
 }

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -188,7 +188,7 @@ async fn test_one_subscriber() {
 
     let account_id: AccountId = "eip155:1:0xfff".into();
     let subscriber_sym_key = hex::encode([0u8; 32]);
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     let subcriber_scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let client_data = ClientData {
         id: account_id.to_string(),
@@ -342,7 +342,7 @@ async fn test_two_subscribers() {
 
     let account_id: AccountId = "eip155:1:0xfff".into();
     let subscriber_sym_key = hex::encode([0u8; 32]);
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     let subcriber_scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let client_data = ClientData {
         id: account_id.to_string(),
@@ -372,7 +372,7 @@ async fn test_two_subscribers() {
 
     let account_id2: AccountId = "eip155:1:0xEEE".into();
     let subscriber_sym_key2 = hex::encode([1u8; 32]);
-    let subscriber_topic2: Topic = "subscriber_topic2".into();
+    let subscriber_topic2: Topic = sha256::digest(&[1u8; 32]).into();
     let subcriber_scope2 = HashSet::from(["scope12".to_string(), "scope22".to_string()]);
     let client_data2 = ClientData {
         id: account_id2.to_string(),
@@ -604,7 +604,7 @@ async fn test_one_subscriber_two_projects() {
 
     let account_id: AccountId = "eip155:1:0xfff".into();
     let subscriber_sym_key = hex::encode([0u8; 32]);
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     let subcriber_scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let client_data = ClientData {
         id: account_id.to_string(),
@@ -632,7 +632,7 @@ async fn test_one_subscriber_two_projects() {
         .await
         .unwrap();
     let subscriber_sym_key2 = hex::encode([1u8; 32]);
-    let subscriber_topic2: Topic = "subscriber_topic2".into();
+    let subscriber_topic2: Topic = sha256::digest(&[1u8; 32]).into();
     let subcriber_scope2 = HashSet::from(["scope12".to_string(), "scope22".to_string()]);
     let client_data2 = ClientData {
         id: account_id.to_string(),
@@ -873,7 +873,7 @@ async fn test_call_migrate_twice() {
 
     let account_id: AccountId = "eip155:1:0xfff".into();
     let subscriber_sym_key = hex::encode([0u8; 32]);
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     let subcriber_scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let client_data = ClientData {
         id: account_id.to_string(),
@@ -901,7 +901,7 @@ async fn test_call_migrate_twice() {
         .await
         .unwrap();
     let subscriber_sym_key2 = hex::encode([1u8; 32]);
-    let subscriber_topic2: Topic = "subscriber_topic2".into();
+    let subscriber_topic2: Topic = sha256::digest(&[1u8; 32]).into();
     let subcriber_scope2 = HashSet::from(["scope12".to_string(), "scope22".to_string()]);
     let client_data2 = ClientData {
         id: account_id.to_string(),
@@ -1117,7 +1117,7 @@ async fn test_lookup_table_entry_missing() {
 
     let account_id: AccountId = "eip155:1:0xfff".into();
     let subscriber_sym_key = hex::encode([0u8; 32]);
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     let subcriber_scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let client_data = ClientData {
         id: account_id.to_string(),
@@ -1229,7 +1229,7 @@ async fn test_client_data_entry_missing() {
         .unwrap();
 
     let account_id: AccountId = "eip155:1:0xfff".into();
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     assert_eq!(
         mongodb
             .collection::<ClientData>(project_id.as_ref())
@@ -1316,7 +1316,7 @@ async fn test_project_data_entry_missing() {
 
     let account_id: AccountId = "eip155:1:0xfff".into();
     let subscriber_sym_key = hex::encode([0u8; 32]);
-    let subscriber_topic: Topic = "subscriber_topic".into();
+    let subscriber_topic: Topic = sha256::digest(&[0u8; 32]).into();
     let subcriber_scope = HashSet::from(["scope1".to_string(), "scope2".to_string()]);
     let client_data = ClientData {
         id: account_id.to_string(),


### PR DESCRIPTION
# Description

Makes the migration more robust by:
- handling the situation where any related rows that should be there that are missing, by ignoring the row
- always lowercasing the AccountId, as some clients follow ERC-55 but others not

Resolves #146 

## How Has This Been Tested?

Tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
