### PR TITLE
fix: break /notify response

### DIFF
--- a/src/handlers/notify.rs
+++ b/src/handlers/notify.rs
@@ -135,7 +135,7 @@ pub async fn handler(
         send_metrics(metrics, &response, timer);
     }
 
-    Ok((StatusCode::OK, Json(response)).into_response())
+    Ok((StatusCode::OK, Json(())).into_response())
 }
 
 const NOTIFY_TIMEOUT: u64 = 45;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -946,12 +946,10 @@ async fn run_test(statement: String) {
         .await
         .unwrap();
 
-    let resp = resp
-        .json::<notify_server::handlers::notify::Response>()
+    resp
+        .json::<()>()
         .await
         .unwrap();
-
-    assert_eq!(resp.not_found.len(), 1);
 
     let unregister_auth = UnregisterIdentityRequestAuth {
         shared_claims: SharedClaims {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -946,10 +946,7 @@ async fn run_test(statement: String) {
         .await
         .unwrap();
 
-    resp
-        .json::<()>()
-        .await
-        .unwrap();
+    resp.json::<()>().await.unwrap();
 
     let unregister_auth = UnregisterIdentityRequestAuth {
         shared_claims: SharedClaims {


### PR DESCRIPTION
# Description

Breaks the `/notify` response in preparation for async queuing of message sends.

Context: https://walletconnect.slack.com/archives/C044SKFKELR/p1698200652529089

Resolves #148

## How Has This Been Tested?

Automated tests

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
