### PR TITLE
fix: did:key app_authentication_key

### DIFF
--- a/src/handlers/subscribe_topic.rs
+++ b/src/handlers/subscribe_topic.rs
@@ -70,16 +70,17 @@ pub async fn handler(
     });
     let signing_public = PublicKey::from(&signing_secret);
     let topic: Topic = sha256::digest(signing_public.as_bytes()).into();
-    let signing_public = hex::encode(signing_public);
-    let signing_secret = hex::encode(signing_secret.to_bytes());
+    let subscribe_public_key = hex::encode(signing_public);
+    let subscribe_private_key = hex::encode(signing_secret.to_bytes());
 
     let identity_secret = ed25519_dalek::SigningKey::generate(&mut rng);
-    let identity_public = hex::encode(ed25519_dalek::VerifyingKey::from(&identity_secret));
-    let identity_secret = hex::encode(identity_secret.to_bytes());
+    let authentication_public_key =
+        hex::encode(ed25519_dalek::VerifyingKey::from(&identity_secret));
+    let authentication_private_key = hex::encode(identity_secret.to_bytes());
 
     info!(
         "Saving project_info to database for project: {project_id} and app_domain {app_domain} \
-         with signing pubkey: {signing_public} and identity pubkey: {identity_public}, topic: \
+         with subscribe_public_key: {subscribe_public_key} and authentication_public_key: {authentication_public_key}, topic: \
          {topic}"
     );
 
@@ -87,10 +88,10 @@ pub async fn handler(
         project_id,
         &app_domain,
         topic.clone(),
-        identity_public,
-        identity_secret,
-        signing_public,
-        signing_secret,
+        authentication_public_key,
+        authentication_private_key,
+        subscribe_public_key,
+        subscribe_private_key,
         &state.postgres,
     )
     .await?;

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -22,10 +22,10 @@ pub async fn upsert_project(
     project_id: ProjectId,
     app_domain: &str,
     topic: Topic,
-    identity_public: String,
-    identity_secret: String,
-    signing_public: String,
-    signing_secret: String,
+    authentication_public_key: String,
+    authentication_private_key: String,
+    subscribe_public_key: String,
+    subscribe_private_key: String,
     postgres: &PgPool,
 ) -> Result<ProjectWithPublicKeys, sqlx::error::Error> {
     let query = "
@@ -48,10 +48,10 @@ pub async fn upsert_project(
         .bind(project_id.as_ref())
         .bind(app_domain)
         .bind(topic.as_ref())
-        .bind(identity_public)
-        .bind(identity_secret)
-        .bind(signing_public)
-        .bind(signing_secret)
+        .bind(authentication_public_key)
+        .bind(authentication_private_key)
+        .bind(subscribe_public_key)
+        .bind(subscribe_private_key)
         .fetch_one(postgres)
         .await
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -621,6 +621,13 @@ async fn run_test(statement: String) {
         );
         assert_eq!(sub.account, account);
         assert_eq!(sub.app_domain, app_domain);
+        assert_eq!(&sub.app_authentication_key, &dapp_did_key);
+        assert_eq!(
+            DecodedClientId::try_from_did_key(&sub.app_authentication_key)
+                .unwrap()
+                .0,
+            decode_key(dapp_identity_pubkey).unwrap()
+        );
         assert_eq!(
             sub.scope,
             HashSet::from(["test".to_owned(), "test1".to_owned()]),


### PR DESCRIPTION
# Description

`app_authentication_key` should be a `did:key` as per the [updated spec](https://github.com/WalletConnect/walletconnect-specs/pull/167).

Resolves #152 

## How Has This Been Tested?

Automated tests

## Due Diligence

* [X] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
