### PR TITLE
fix: watcher account not updated

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -433,6 +433,8 @@ pub async fn upsert_subscription_watcher(
             )
             VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (did_key) DO UPDATE SET
+                account=$1,
+                project=$2,
                 sym_key=$4,
                 expiry=$5,
                 updated_at=now()


### PR DESCRIPTION
# Description

As per the specs, account is supposed to be updated if the same did:key is used to call watchSubscriptions. Furthremore, it makes sense to update the `app` being watched, so I submitted a [specs change](https://github.com/WalletConnect/walletconnect-specs/pull/168/files) for this too.

Resolves #156 

## How Has This Been Tested?

Not tested. Not covered by automated tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
