### PR TITLE
fix: DocumentDB Available Memory alarm

### DIFF
--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -64,7 +64,7 @@ variable "docdb_cpu_threshold" {
 variable "docdb_memory_threshold" {
   description = "The DocumentDB available memory alarm threshold in GiB"
   type        = number
-  default     = 3
+  default     = 2
 }
 
 variable "docdb_low_memory_throttling_threshold" {


### PR DESCRIPTION
# Description

Increase the threshold for DocumentDB memory alarms. We will be removing DocumentDB soon enough, and is no longer written to, and in-fact is basically empty now after the migration.

Context: https://walletconnect.slack.com/archives/C05S6CH27HC/p1698659213137829?thread_ts=1698580949.468659&cid=C05S6CH27HC

Resolves #164

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
