### PR TITLE
fix: log JWT iss

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,6 +16,7 @@ use {
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     serde_json::Value,
     std::{collections::HashSet, time::Duration},
+    tracing::info,
     url::Url,
 };
 
@@ -252,6 +253,8 @@ pub fn from_jwt<T: DeserializeOwned + GetSharedClaims>(jwt: &str) -> Result<T> {
 
     let claims = base64::engine::general_purpose::STANDARD_NO_PAD.decode(claims)?;
     let claims = serde_json::from_slice::<T>(&claims)?;
+
+    info!("iss: {}", claims.get_shared_claims().iss);
 
     if claims.get_shared_claims().exp < Utc::now().timestamp().unsigned_abs() {
         Err(AuthError::JwtExpired)?;


### PR DESCRIPTION
# Description

Logs the JWT `iss` (the identity key public key) which helps in debugging errors. This can also help identify malicious users and block them in the Keys Server.

Resolves #179

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
