### PR TITLE
chore: disable cog check

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ clean:
   cargo clean
 
 # Lint the project for any quality issues
-lint: check fmt clippy commit-check
+lint: check fmt clippy
 
 amigood: lint test test-all lint-tf
 
@@ -81,18 +81,6 @@ fmt-imports:
     cargo +nightly fmt -- --config group_imports=StdExternalCrate,imports_granularity=One
   else
     echo '==> rustfmt not found in PATH, skipping'
-  fi
-
-# Run commit checker
-commit-check:
-  #!/bin/bash
-  set -euo pipefail
-
-  if command -v cog >/dev/null; then
-    echo '==> Running cog check'
-    cog check --from-latest-tag
-  else
-    echo '==> cog not found in PATH, skipping'
   fi
 
 lint-tf: tf-validate tf-fmt tfsec tflint


### PR DESCRIPTION
# Description

Disable conventional commit check because the CI check is only on PR names now, which becomes the name of the squashed commit.

## How Has This Been Tested?

`just lint`

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
