### PR TITLE
fix: always in alarm state

### DIFF
--- a/terraform/monitoring/panels/app/relay_incomming_message_server_errors.libsonnet
+++ b/terraform/monitoring/panels/app/relay_incomming_message_server_errors.libsonnet
@@ -17,6 +17,7 @@ local targets   = grafana.targets;
       name          = '%(env)s - Failed to process incomming relay message' % { env: vars.environment },
       message       = '%(env)s - Failed to process incomming relay message' % { env: vars.environment },
       notifications = vars.notifications,
+      noDataState   = 'no_data',
       conditions    = [
         grafana.alertCondition.new(
           evaluatorParams = [ 1 ],

--- a/terraform/monitoring/panels/app/relay_outgoing_message_failures.libsonnet
+++ b/terraform/monitoring/panels/app/relay_outgoing_message_failures.libsonnet
@@ -17,6 +17,7 @@ local targets   = grafana.targets;
       name          = '%(env)s - Failed to publish to relay'         % { env: vars.environment },
       message       = '%(env)s - Failed to publish message to relay' % { env: vars.environment },
       notifications = vars.notifications,
+      noDataState   = 'no_data',
       conditions    = [
         grafana.alertCondition.new(
           evaluatorParams = [ 1 ],


### PR DESCRIPTION
# Description

Fixes alarms alarming when there is no data. Errors happen rarely so we don't expect there to be data most of the time.

Resolves # (issue)

## How Has This Been Tested?

Not tested. Copied from the other charts: https://github.com/WalletConnect/notify-server/blob/b0a7d9d56396c31673521bbdeb8aa1abe7ca69f3/terraform/monitoring/panels/lb/error_5xx.libsonnet#L25

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
