### PR TITLE
feat(metrics): adding messages queue stats

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -37,6 +37,9 @@ pub struct Metrics {
     pub notify_latency: Histogram<u64>,
     pub publishing_workers_count: ObservableGauge<u64>,
     pub publishing_workers_errors: Counter<u64>,
+    pub publishing_queue_queued_size: ObservableGauge<u64>,
+    pub publishing_queue_processing_size: ObservableGauge<u64>,
+    pub publishing_queue_published_count: Counter<u64>,
 }
 
 impl Metrics {
@@ -125,6 +128,21 @@ impl Metrics {
             .with_description("The number of publishing worker that ended with an error")
             .init();
 
+        let publishing_queue_queued_size = meter
+            .u64_observable_gauge("publishing_queue_queued_size")
+            .with_description("The messages publishing queue size in queued state")
+            .init();
+
+        let publishing_queue_processing_size = meter
+            .u64_observable_gauge("publishing_queue_processing_size")
+            .with_description("The messages publishing queue size in processing state")
+            .init();
+
+        let publishing_queue_published_count = meter
+            .u64_counter("publishing_queue_published_count")
+            .with_description("The number of published messages by workers")
+            .init();
+
         Metrics {
             subscribed_project_topics,
             subscribed_subscriber_topics,
@@ -142,6 +160,9 @@ impl Metrics {
             notify_latency,
             publishing_workers_count,
             publishing_workers_errors,
+            publishing_queue_queued_size,
+            publishing_queue_processing_size,
+            publishing_queue_published_count,
         }
     }
 }

--- a/src/services/publisher_service/types.rs
+++ b/src/services/publisher_service/types.rs
@@ -1,4 +1,7 @@
-use std::{fmt, str::FromStr};
+use {
+    sqlx::FromRow,
+    std::{fmt, str::FromStr},
+};
 
 #[derive(Debug, PartialEq)]
 pub enum SubscriberNotificationStatus {
@@ -36,4 +39,10 @@ impl FromStr for SubscriberNotificationStatus {
             _ => Err(format!("'{}' is not a valid state", s)),
         }
     }
+}
+
+#[derive(Debug, FromRow)]
+pub struct PublishingQueueStats {
+    pub queued: i64,
+    pub processing: i64,
 }

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -68,6 +68,14 @@ dashboard.new(
     panels.app.relay_outgoing_message_latency(ds, vars)             {gridPos: pos._6 },
     panels.app.relay_outgoing_message_failures(ds, vars)            {gridPos: pos._6 },
 
+  row.new('Application publisher subservice'),
+    panels.app.publishing_workers_count(ds, vars)                   {gridPos: pos._5 },
+    panels.app.publishing_workers_errors(ds, vars)                  {gridPos: pos._5 },
+    panels.app.publishing_workers_queued_size(ds, vars)             {gridPos: pos._5 },
+
+    panels.app.publishing_workers_processing_size(ds, vars)         {gridPos: pos._5 },
+    panels.app.publishing_workers_published_count(ds, vars)         {gridPos: pos._5 },
+
   row.new('Deprecated metrics'),
     panels.app.notify_latency(ds, vars)             { gridPos: pos._4 },
     panels.app.dispatched_notifications(ds, vars)   { gridPos: pos._4 },

--- a/terraform/monitoring/panels/app/publishing_workers_processing_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_processing_size.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Messages in processing state',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr        = 'sum(publishing_queue_processing_size{})',
+      refId       = "pub_processing_size",
+    ))
+}

--- a/terraform/monitoring/panels/app/publishing_workers_published_count.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_published_count.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Published messages count',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr        = 'sum(rate(publishing_queue_published_count_total{}[$__rate_interval]))',
+      refId       = "pub_published_count",
+    ))
+}

--- a/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Messages queue size',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr        = 'sum(publishing_queue_queued_size{})',
+      refId       = "pub_msgs_queue_size",
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -28,6 +28,9 @@ local docdb_mem_threshold = units.size_bin(GiB = docdb_mem * 0.1);
     account_not_found:                          (import 'app/account_not_found.libsonnet'                          ).new,
     publishing_workers_count:                   (import 'app/publishing_workers_count.libsonnet'                   ).new,
     publishing_workers_errors:                  (import 'app/publishing_workers_errors.libsonnet'                  ).new,
+    publishing_workers_queued_size:             (import 'app/publishing_workers_queued_size.libsonnet'             ).new,
+    publishing_workers_processing_size:         (import 'app/publishing_workers_processing_size.libsonnet'         ).new,
+    publishing_workers_published_count:         (import 'app/publishing_workers_published_count.libsonnet'         ).new,
   },
   ecs: {
     cpu(ds, vars):            ecs.cpu.panel(ds.cloudwatch, vars.namespace, vars.environment, vars.notifications, vars.ecs_service_name, vars.ecs_cluster_name),


### PR DESCRIPTION
# Description

This PR adds metrics for message queue size and statuses:
* Current messages queue size in `queued` state,
* Current messages queue size in `processing` state,
* Counter for messages marked as `published`.

Queue sizes are collected by polling the database with the count query in a minute interval and storing the result in the observable gauge.
The published counter is populated during the message status update.

Following Grafana panels were added:
* Spawned publishing workers count (ref. #192 ),
* Publishing workers error count (ref #192 ),
* Count of messages in queued state,
* Count of messages in processing state,
* Published messages counter.

Resolves #189 

## How Has This Been Tested?

Only local smoke test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
