### PR TITLE
refactor: using only `update_message_processing_status` to change status

### DIFF
--- a/src/services/publisher_service/helpers.rs
+++ b/src/services/publisher_service/helpers.rs
@@ -153,15 +153,12 @@ pub async fn pick_subscriber_notification_for_processing(
 }
 
 #[instrument(skip(postgres, metrics))]
-pub async fn update_message_processing_status<'e, E>(
+pub async fn update_message_processing_status<'e>(
     notification: Uuid,
     status: SubscriberNotificationStatus,
-    postgres: E,
+    postgres: impl sqlx::PgExecutor<'e>,
     metrics: Option<&Metrics>,
-) -> std::result::Result<(), sqlx::error::Error>
-where
-    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
-{
+) -> std::result::Result<(), sqlx::error::Error> {
     let mark_message_as_processed = "
         UPDATE subscriber_notification
         SET updated_at=now(),


### PR DESCRIPTION
# Description

This PR adds a small refactor to use `update_message_processing_status` helper function to change the message status instead of manually running the SQL.
This is useful for tracking metrics inside the `update_message_processing_status` function and following the DRY.

* Making `update_message_processing_status only to change status` to be used with PgPool and Pg transactions,
* Refactor the place of using it.

Resolves #189

## How Has This Been Tested?

Just a build-and-up local smoke test.

## Due Diligence

* [x] 🚧 Stacked on top of #200 
* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
