### PR TITLE
chore: style sql

### DIFF
--- a/migrations/20231018121518_init.sql
+++ b/migrations/20231018121518_init.sql
@@ -1,31 +1,31 @@
 CREATE TABLE project (
-    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    inserted_at TIMESTAMPTZ NOT NULL    DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL    DEFAULT now(),
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    inserted_at timestamptz NOT NULL    DEFAULT now(),
+    updated_at  timestamptz NOT NULL    DEFAULT now(),
 
-    project_id VARCHAR(255) NOT NULL UNIQUE,
-    app_domain VARCHAR(255) NOT NULL UNIQUE,
-    topic      VARCHAR(255) NOT NULL UNIQUE,
+    project_id varchar(255) NOT NULL UNIQUE,
+    app_domain varchar(255) NOT NULL UNIQUE,
+    topic      varchar(255) NOT NULL UNIQUE,
 
-    authentication_public_key  VARCHAR(255) NOT NULL UNIQUE,
-    authentication_private_key VARCHAR(255) NOT NULL UNIQUE,
-    subscribe_public_key       VARCHAR(255) NOT NULL UNIQUE,
-    subscribe_private_key      VARCHAR(255) NOT NULL UNIQUE
+    authentication_public_key  varchar(255) NOT NULL UNIQUE,
+    authentication_private_key varchar(255) NOT NULL UNIQUE,
+    subscribe_public_key       varchar(255) NOT NULL UNIQUE,
+    subscribe_private_key      varchar(255) NOT NULL UNIQUE
 );
 CREATE INDEX projects_project_id_idx ON project (project_id);
 CREATE INDEX projects_app_domain_idx ON project (app_domain);
 CREATE INDEX projects_topic_idx      ON project (topic);
 
 CREATE TABLE subscriber (
-    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    inserted_at TIMESTAMPTZ NOT NULL    DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL    DEFAULT now(),
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    inserted_at timestamptz NOT NULL    DEFAULT now(),
+    updated_at  timestamptz NOT NULL    DEFAULT now(),
 
-    project UUID         NOT NULL REFERENCES project (id) ON DELETE CASCADE,
-    account VARCHAR(255) NOT NULL,
-    sym_key VARCHAR(255) NOT NULL UNIQUE,
-    topic   VARCHAR(255) NOT NULL UNIQUE,
-    expiry  TIMESTAMPTZ  NOT NULL,
+    project uuid         NOT NULL REFERENCES project (id) ON DELETE CASCADE,
+    account varchar(255) NOT NULL,
+    sym_key varchar(255) NOT NULL UNIQUE,
+    topic   varchar(255) NOT NULL UNIQUE,
+    expiry  timestamptz  NOT NULL,
 
     UNIQUE (project, account)
 );
@@ -35,12 +35,12 @@ CREATE INDEX subscribers_topic_idx   ON subscriber (topic);
 CREATE INDEX subscribers_expiry_idx  ON subscriber (expiry);
 
 CREATE TABLE subscriber_scope (
-    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    inserted_at TIMESTAMPTZ NOT NULL    DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL    DEFAULT now(),
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    inserted_at timestamptz NOT NULL    DEFAULT now(),
+    updated_at  timestamptz NOT NULL    DEFAULT now(),
 
-    subscriber UUID         NOT NULL REFERENCES subscriber (id) ON DELETE CASCADE,
-    name       VARCHAR(255) NOT NULL,
+    subscriber uuid         NOT NULL REFERENCES subscriber (id) ON DELETE CASCADE,
+    name       varchar(255) NOT NULL,
 
     UNIQUE (subscriber, name)
 );
@@ -48,15 +48,15 @@ CREATE INDEX subscriber_scope_subscriber_idx ON subscriber_scope (subscriber);
 CREATE INDEX subscriber_scope_name_idx       ON subscriber_scope (name);
 
 CREATE TABLE subscription_watcher (
-    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    inserted_at TIMESTAMPTZ NOT NULL    DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL    DEFAULT now(),
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    inserted_at timestamptz NOT NULL    DEFAULT now(),
+    updated_at  timestamptz NOT NULL    DEFAULT now(),
 
-    account VARCHAR(255) NOT NULL,
-    project UUID         REFERENCES project (id) ON DELETE CASCADE,
-    did_key VARCHAR(255) NOT NULL UNIQUE,
-    sym_key VARCHAR(255) NOT NULL,
-    expiry  TIMESTAMPTZ  NOT NULL
+    account varchar(255) NOT NULL,
+    project uuid         REFERENCES project (id) ON DELETE CASCADE,
+    did_key varchar(255) NOT NULL UNIQUE,
+    sym_key varchar(255) NOT NULL,
+    expiry  timestamptz  NOT NULL
 );
 CREATE INDEX subscription_watcher_account_idx ON subscription_watcher (account);
 CREATE INDEX subscription_watcher_project_idx ON subscription_watcher (project);

--- a/migrations/20231025145134_add_notification.sql
+++ b/migrations/20231025145134_add_notification.sql
@@ -1,14 +1,14 @@
 CREATE TABLE notification (
-    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    project         UUID         NOT NULL REFERENCES project (id) ON DELETE CASCADE,
-    notification_id VARCHAR(255) NOT NULL,
-    type            UUID         NOT NULL,
-    title           VARCHAR(255) NOT NULL,
-    body            VARCHAR(255) NOT NULL,
-    icon            VARCHAR(255), -- nullable
-    url             VARCHAR(255), -- nullable
+    id              uuid         PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at      timestamptz  NOT NULL DEFAULT now(),
+    updated_at      timestamptz  NOT NULL DEFAULT now(),
+    project         uuid         NOT NULL REFERENCES project (id) ON DELETE CASCADE,
+    notification_id varchar(255) NOT NULL,
+    type            uuid         NOT NULL,
+    title           varchar(255) NOT NULL,
+    body            varchar(255) NOT NULL,
+    icon            varchar(255) NULL,
+    url             varchar(255) NULL,
 
     UNIQUE (project, notification_id)
 );
@@ -20,11 +20,11 @@ CREATE TYPE subscriber_notification_status
   AS ENUM ('queued', 'processing', 'published', 'failed');
 
 CREATE TABLE subscriber_notification (
-    id            UUID                            PRIMARY KEY DEFAULT gen_random_uuid(),
-    created_at    TIMESTAMPTZ                     NOT NULL DEFAULT now(),
-    updated_at    TIMESTAMPTZ                     NOT NULL DEFAULT now(),
-    notification  UUID                            NOT NULL REFERENCES notification (id) ON DELETE CASCADE,
-    subscriber    UUID                            NOT NULL REFERENCES subscriber (id) ON DELETE CASCADE,
+    id            uuid                            PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at    timestamptz                     NOT NULL DEFAULT now(),
+    updated_at    timestamptz                     NOT NULL DEFAULT now(),
+    notification  uuid                            NOT NULL REFERENCES notification (id) ON DELETE CASCADE,
+    subscriber    uuid                            NOT NULL REFERENCES subscriber (id) ON DELETE CASCADE,
     status        subscriber_notification_status  NOT NULL,
 
     UNIQUE (notification, subscriber)


### PR DESCRIPTION
# Description

Make SQL style consistent. While it's generally a bad idea to change existing migrations, these should be functionally equivalent and won't be rerun anyway because the migration ID is what determines if the migration was already run or not.

This copies the style in [echo-server](https://github.com/WalletConnect/echo-server/pull/277).

This style matches what I've generally seen in the Postgres documentation:
- lowercase type names

Furthermore, I took the liberty of explicitly specifying `NULL` constraint which is equivalent to no `NOT NULL` which I verified by checking `\d+ notification`

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
