### PR TITLE
fix: switch Grafana dashboard to UTC

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -39,6 +39,7 @@ dashboard.new(
   uid           = std.extVar('dashboard_uid'),
   editable      = true,
   graphTooltip  = dashboard.graphTooltips.sharedCrosshair,
+  timezone      = dashboard.timezones.utc,
 )
 .addAnnotation(
   annotation.new(


### PR DESCRIPTION
# Description

Easier to correlate with e.g. log entries or other team members.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
