### PR TITLE
fix: alarm immediately

### DIFF
--- a/terraform/monitoring/panels/app/relay_incomming_message_server_errors.libsonnet
+++ b/terraform/monitoring/panels/app/relay_incomming_message_server_errors.libsonnet
@@ -18,9 +18,10 @@ local targets   = grafana.targets;
       message       = '%(env)s - Failed to process incomming relay message' % { env: vars.environment },
       notifications = vars.notifications,
       noDataState   = 'no_data',
+      period        = '0m',
       conditions    = [
         grafana.alertCondition.new(
-          evaluatorParams = [ 1 ],
+          evaluatorParams = [ 0 ],
           evaluatorType   = 'gt',
           operatorType    = 'or',
           queryRefId      = 'RelayIncommingMessagesServerErrors',

--- a/terraform/monitoring/panels/app/relay_outgoing_message_failures.libsonnet
+++ b/terraform/monitoring/panels/app/relay_outgoing_message_failures.libsonnet
@@ -18,9 +18,10 @@ local targets   = grafana.targets;
       message       = '%(env)s - Failed to publish message to relay' % { env: vars.environment },
       notifications = vars.notifications,
       noDataState   = 'no_data',
+      period        = '0m',
       conditions    = [
         grafana.alertCondition.new(
-          evaluatorParams = [ 1 ],
+          evaluatorParams = [ 0 ],
           evaluatorType   = 'gt',
           operatorType    = 'or',
           queryRefId      = 'RelayOutgoingMessagePermenantFailures',

--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -4,7 +4,7 @@ local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
 local panels    = grafana.panels;
 local targets   = grafana.targets;
 
-local threshold = 1;
+local threshold = 0;
 
 local _configuration = defaults.configuration.timeseries
   .withSoftLimit(
@@ -23,6 +23,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
   message       = '%(env)s - Notify - 5XX alert'  % { env: grafana.utils.strings.capitalize(env) },
   notifications = notifications,
   noDataState   = 'no_data',
+  period        = '0m',
   conditions    = [
     grafana.alertCondition.new(
       evaluatorParams = [ threshold ],


### PR DESCRIPTION
# Description

Alarms after >0 notifications, not >1. And alarms after 0 minutes of triggering, not after 5 minutes of it triggering.

This should actually catch all errors.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
