### PR TITLE
fix: no 500 on app domain conflict

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -439,8 +439,8 @@ pub async fn verify_identity(iss: &str, ksu: &str, sub: &str) -> Result<Authoriz
         return Err(AuthError::KeyserverUnsuccessfulResponse {
             status: response.status(),
             response,
-        })
-        .map_err(Into::into);
+        }
+        .into());
     }
 
     let keyserver_response = response.json::<KeyServerResponse>().await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -180,6 +180,9 @@ pub enum Error {
 
     #[error("Bad request: {0}")]
     BadRequest(String),
+
+    #[error("App domain in-use by another project")]
+    AppDomainInUseByAnotherProject,
 }
 
 impl IntoResponse for Error {
@@ -195,6 +198,9 @@ impl IntoResponse for Error {
                 })),
             )
                 .into_response(),
+            Self::AppDomainInUseByAnotherProject => {
+                (StatusCode::CONFLICT, self.to_string()).into_response()
+            }
             error => {
                 error!("Unhandled error: {:?}", error);
                 (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error.").into_response()

--- a/src/services/public_http_server/handlers/subscribe_topic.rs
+++ b/src/services/public_http_server/handlers/subscribe_topic.rs
@@ -22,11 +22,11 @@ pub struct SubscribeTopicRequestData {
     pub app_domain: String,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeTopicResponseData {
-    authentication_key: String,
-    subscribe_key: String,
+    pub authentication_key: String,
+    pub subscribe_key: String,
 }
 
 #[instrument(name = "notify_v1", skip(state, subscribe_topic_data))]

--- a/tests/deployment.rs
+++ b/tests/deployment.rs
@@ -23,7 +23,8 @@ use {
         model::types::AccountId,
         services::{
             public_http_server::handlers::{
-                notify_v0::NotifyBody, subscribe_topic::SubscribeTopicRequestData,
+                notify_v0::NotifyBody,
+                subscribe_topic::{SubscribeTopicRequestData, SubscribeTopicResponseData},
             },
             websocket_server::{
                 decode_key, derive_key, relay_ws_client::RelayClientEvent, NotifyRequest,
@@ -441,8 +442,10 @@ async fn run_test(statement: String, watch_subscriptions_all_domains: bool) {
         .await
         .unwrap();
     assert_eq!(subscribe_topic_response.status(), StatusCode::OK);
-    let subscribe_topic_response_body: serde_json::Value =
-        subscribe_topic_response.json().await.unwrap();
+    let subscribe_topic_response_body = subscribe_topic_response
+        .json::<SubscribeTopicResponseData>()
+        .await
+        .unwrap();
 
     let watch_topic_key = {
         let (subs, watch_topic_key) = watch_subscriptions(
@@ -465,20 +468,8 @@ async fn run_test(statement: String, watch_subscriptions_all_domains: bool) {
         watch_topic_key
     };
 
-    // Get app public key
-    // TODO use struct
-    let app_subscribe_public_key = subscribe_topic_response_body
-        .get("subscribeKey")
-        .unwrap()
-        .as_str()
-        .unwrap();
-
-    // TODO use struct
-    let app_authentication_public_key = subscribe_topic_response_body
-        .get("authenticationKey")
-        .unwrap()
-        .as_str()
-        .unwrap();
+    let app_subscribe_public_key = &subscribe_topic_response_body.subscribe_key;
+    let app_authentication_public_key = &subscribe_topic_response_body.authentication_key;
     let dapp_did_key = format!(
         "did:key:{}",
         DecodedClientId(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -27,6 +27,7 @@ use {
         services::{
             public_http_server::handlers::{
                 notify_v0::NotifyBody, notify_v1::NotifyBodyNotification,
+                subscribe_topic::SubscribeTopicRequestData,
             },
             publisher_service::helpers::{
                 dead_letter_give_up_check, dead_letters_check,
@@ -1677,4 +1678,130 @@ async fn test_dead_letter_and_giveup_checks() {
             .await
             .unwrap();
     assert!(give_up_result_after);
+}
+
+#[test_context(NotifyServerContext)]
+#[tokio::test]
+async fn test_subscribe_topic(notify_server: &NotifyServerContext) {
+    let project_id = ProjectId::generate();
+    let app_domain = &generate_app_domain();
+    let subscribe_topic_response = reqwest::Client::new()
+        .post(
+            notify_server
+                .url
+                .join(&format!("/{project_id}/subscribe-topic",))
+                .unwrap(),
+        )
+        .bearer_auth(Uuid::new_v4().to_string())
+        .json(&SubscribeTopicRequestData {
+            app_domain: app_domain.to_owned(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subscribe_topic_response.status(), StatusCode::OK);
+
+    let subscribe_topic_response_body: serde_json::Value =
+        subscribe_topic_response.json().await.unwrap();
+    // TODO use struct
+    let app_subscribe_public_key = subscribe_topic_response_body
+        .get("subscribeKey")
+        .unwrap()
+        .as_str()
+        .unwrap();
+
+    // TODO use struct
+    let app_authentication_public_key = subscribe_topic_response_body
+        .get("authenticationKey")
+        .unwrap()
+        .as_str()
+        .unwrap();
+
+    let project = get_project_by_project_id(project_id.clone(), &notify_server.postgres)
+        .await
+        .unwrap();
+    assert_eq!(project.subscribe_public_key, app_subscribe_public_key);
+    assert_eq!(
+        project.authentication_public_key,
+        app_authentication_public_key
+    );
+}
+
+#[test_context(NotifyServerContext)]
+#[tokio::test]
+async fn test_subscribe_topic_idempotency(notify_server: &NotifyServerContext) {
+    let project_id = ProjectId::generate();
+    let app_domain = &generate_app_domain();
+
+    let subscribe_topic_response = reqwest::Client::new()
+        .post(
+            notify_server
+                .url
+                .join(&format!("/{project_id}/subscribe-topic",))
+                .unwrap(),
+        )
+        .bearer_auth(Uuid::new_v4().to_string())
+        .json(&SubscribeTopicRequestData {
+            app_domain: app_domain.to_owned(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subscribe_topic_response.status(), StatusCode::OK);
+
+    let subscribe_topic_response = reqwest::Client::new()
+        .post(
+            notify_server
+                .url
+                .join(&format!("/{project_id}/subscribe-topic",))
+                .unwrap(),
+        )
+        .bearer_auth(Uuid::new_v4().to_string())
+        .json(&SubscribeTopicRequestData {
+            app_domain: app_domain.to_owned(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subscribe_topic_response.status(), StatusCode::OK);
+}
+
+#[test_context(NotifyServerContext)]
+#[tokio::test]
+async fn test_subscribe_topic_conflict(notify_server: &NotifyServerContext) {
+    let project_id = ProjectId::generate();
+    let app_domain = &generate_app_domain();
+
+    let subscribe_topic_response = reqwest::Client::new()
+        .post(
+            notify_server
+                .url
+                .join(&format!("/{project_id}/subscribe-topic",))
+                .unwrap(),
+        )
+        .bearer_auth(Uuid::new_v4().to_string())
+        .json(&SubscribeTopicRequestData {
+            app_domain: app_domain.to_owned(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subscribe_topic_response.status(), StatusCode::OK);
+
+    let project_id = ProjectId::generate();
+    let subscribe_topic_response = reqwest::Client::new()
+        .post(
+            notify_server
+                .url
+                .join(&format!("/{project_id}/subscribe-topic",))
+                .unwrap(),
+        )
+        .bearer_auth(Uuid::new_v4().to_string())
+        .json(&SubscribeTopicRequestData {
+            app_domain: app_domain.to_owned(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(subscribe_topic_response.status(), StatusCode::CONFLICT);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -26,8 +26,9 @@ use {
         registry::RegistryAuthResponse,
         services::{
             public_http_server::handlers::{
-                notify_v0::NotifyBody, notify_v1::NotifyBodyNotification,
-                subscribe_topic::SubscribeTopicRequestData,
+                notify_v0::NotifyBody,
+                notify_v1::NotifyBodyNotification,
+                subscribe_topic::{SubscribeTopicRequestData, SubscribeTopicResponseData},
             },
             publisher_service::helpers::{
                 dead_letter_give_up_check, dead_letters_check,
@@ -1701,29 +1702,18 @@ async fn test_subscribe_topic(notify_server: &NotifyServerContext) {
         .unwrap();
     assert_eq!(subscribe_topic_response.status(), StatusCode::OK);
 
-    let subscribe_topic_response_body: serde_json::Value =
-        subscribe_topic_response.json().await.unwrap();
-    // TODO use struct
-    let app_subscribe_public_key = subscribe_topic_response_body
-        .get("subscribeKey")
-        .unwrap()
-        .as_str()
-        .unwrap();
-
-    // TODO use struct
-    let app_authentication_public_key = subscribe_topic_response_body
-        .get("authenticationKey")
-        .unwrap()
-        .as_str()
+    let response = subscribe_topic_response
+        .json::<SubscribeTopicResponseData>()
+        .await
         .unwrap();
 
     let project = get_project_by_project_id(project_id.clone(), &notify_server.postgres)
         .await
         .unwrap();
-    assert_eq!(project.subscribe_public_key, app_subscribe_public_key);
+    assert_eq!(project.subscribe_public_key, response.subscribe_key);
     assert_eq!(
         project.authentication_public_key,
-        app_authentication_public_key
+        response.authentication_key
     );
 }
 


### PR DESCRIPTION
# Description

- Fixes the server error when app domain is already taken by another project ID
- Tests the idempotency of `/subscribe-topic` endpoint

Resolves #199

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
