### PR TITLE
fix: remove failed to send alarm

### DIFF
--- a/src/services/public_http_server/handlers/notify_v1.rs
+++ b/src/services/public_http_server/handlers/notify_v1.rs
@@ -100,7 +100,6 @@ pub async fn handler_impl(
         // We assume all accounts were not found until found
         response.not_found.extend(accounts.iter().cloned());
 
-        // FIXME this is inefficient to get all subscribers when only a subset are in the request
         let subscribers = get_subscribers_for_project_in(
             project.id,
             &accounts,

--- a/terraform/monitoring/panels/app/send_failed.libsonnet
+++ b/terraform/monitoring/panels/app/send_failed.libsonnet
@@ -18,25 +18,6 @@ local _configuration = defaults.configuration.timeseries
   })
   .withColor(grafana.fieldConfig.colorMode.Thresholds);
 
-
-local _alert(namespace, env, notifications) = grafana.alert.new(
-  namespace     = namespace,
-  name          = "%(env)s - Failing on send (communicating with relay)"                                    % { env: env },
-  message       = '%(env)s - Failing to send messages, potential problem with Notify <-> Relay communication' % { env: env },
-  notifications = notifications,
-  conditions    = [
-    grafana.alertCondition.new(
-      evaluatorParams = [ threshold ],
-      evaluatorType   = 'gt',
-      operatorType    = 'and',
-      queryRefId      = 'NotificationsFailed',
-      queryTimeStart  = '5m',
-      queryTimeEnd    = 'now',
-      reducerType     = grafana.alert_reducers.Sum
-    ),
-  ],
-);
-
 {
   new(ds, vars)::
     panels.timeseries(
@@ -44,11 +25,6 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       datasource  = ds.prometheus,
     )
     .configure(_configuration)
-
-    .setAlert(
-      vars.environment,
-      _alert(vars.namespace, vars.environment, vars.notifications)
-    )
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,


### PR DESCRIPTION
# Description

This metric is outdated since we have the new publisher service. Any failures are now the result of an improper scope, which is a client-facing "error" and in many cases may even be normal behavior.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
