### PR TITLE
fix: limit to /notify 500 notifications

### DIFF
--- a/src/services/public_http_server/handlers/notify_v0.rs
+++ b/src/services/public_http_server/handlers/notify_v0.rs
@@ -13,6 +13,8 @@ use {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NotifyBody {
+    #[serde(default)]
+    pub notification_id: Option<String>,
     pub notification: Notification,
     pub accounts: Vec<AccountId>,
 }
@@ -40,7 +42,7 @@ pub async fn handler(
         state,
         authed_project_id,
         Json(vec![notify_v1::NotifyBodyNotification {
-            notification_id: None,
+            notification_id: notify_args.notification_id,
             notification: notify_args.notification,
             accounts: notify_args.accounts,
         }]),

--- a/tests/deployment.rs
+++ b/tests/deployment.rs
@@ -692,6 +692,7 @@ async fn run_test(statement: String, watch_subscriptions_all_domains: bool) {
     };
 
     let notify_body = NotifyBody {
+        notification_id: None,
         notification: notification.clone(),
         accounts: vec![account],
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1146,6 +1146,7 @@ async fn test_notify_v0(notify_server: &NotifyServerContext) {
     };
 
     let notify_body = NotifyBody {
+        notification_id: None,
         notification: notification.clone(),
         accounts: vec![account.clone()],
     };


### PR DESCRIPTION
# Description

Limits the number of accounts in a single `/notify` request to 500. This prevents the server from being overloaded with too many accounts and taking too long to process a request. Senders needing to send more than 500 must issue multiple requests to send everything. For now setting to a nice conservative 500, but we can increase this in the future. Depends on https://github.com/WalletConnect/gm-cron/pull/10

Also fixes the validation of notifications to be done before any sending takes place.

Add `notification_id` idempotency key to v0 notify endpoint so that gm-cron can use it.

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
