### PR TITLE
fix: propagate wrong project ID

### DIFF
--- a/src/services/public_http_server/mod.rs
+++ b/src/services/public_http_server/mod.rs
@@ -33,7 +33,11 @@ pub async fn start(
     let global_middleware = ServiceBuilder::new()
         .layer(
             TraceLayer::new_for_http()
-                .make_span_with(DefaultMakeSpan::new().include_headers(true))
+                .make_span_with(
+                    DefaultMakeSpan::new()
+                        .level(Level::INFO)
+                        .include_headers(true),
+                )
                 .on_request(DefaultOnRequest::new().level(Level::INFO))
                 .on_response(
                     DefaultOnResponse::new()

--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -216,7 +216,7 @@ async fn process_queued_messages(
             );
 
             match process_result.await {
-                Ok(_) => {
+                Ok(()) => {
                     update_message_processing_status(
                         notification_id,
                         SubscriberNotificationStatus::Published,


### PR DESCRIPTION
# Description

- Fixes 500 error when project not found.
- Change `make_span_with` to be INFO log (from default of DEBUG) so that "Unhandled errors" are easier to debug
- `Ok(_)` -> `Ok(())` to be explicit that nothing is being ignored

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
