### PR TITLE
fix: notification idempotency

### DIFF
--- a/src/services/publisher_service/helpers.rs
+++ b/src/services/publisher_service/helpers.rs
@@ -36,7 +36,8 @@ pub async fn upsert_notification(
     let query = "
         INSERT INTO notification (project, notification_id, type, title, body, icon, url)
         VALUES ($1, $2, $3, $4, $5, $6, $7)
-        ON CONFLICT (project, notification_id) DO NOTHING
+        ON CONFLICT (project, notification_id) DO UPDATE SET
+            notification_id=EXCLUDED.notification_id
         RETURNING id, type, title, body, icon, url
     ";
     let start = Instant::now();


### PR DESCRIPTION
# Description

Fixes idempotency. This would give a RowNotFound error because `DO NOTHING` results in no results. We have to `DO UPDATE` and actually update something, then `RETURNING` will give results.

Didn't have tests for this before :/

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
