### PR TITLE
fix: increase publisher worker count

### DIFF
--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -37,9 +37,9 @@ pub mod types;
 
 // TODO: These should be configurable, add to the config
 /// Maximum of the parallel messages processing workers
-const MAX_WORKERS: usize = 10;
+const MAX_WORKERS: usize = 20;
 /// Number of workers to be spawned on the service start to clean the queue
-const START_WORKERS: usize = 10;
+const START_WORKERS: usize = 20;
 // Messages queue stats observing database polling interval
 const QUEUE_STATS_POLLING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 /// Maximum publishing time before the publish will be considered as failed


### PR DESCRIPTION
# Description

Increase the worker count. Currently takes 15 minutes to process the GM queue, this will make that 5 minutes. Need to keep bumping this to handle more sends but taking it one step at a time.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
