### PR TITLE
fix: avoid redundant subscribe

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -23,6 +23,7 @@ use {
 pub struct ProjectWithPublicKeys {
     pub authentication_public_key: String,
     pub subscribe_public_key: String,
+    pub topic: String,
 }
 
 pub async fn upsert_project(
@@ -80,7 +81,7 @@ async fn upsert_project_impl(
         ON CONFLICT (project_id) DO UPDATE SET
             updated_at=now(),
             app_domain=$2
-        RETURNING authentication_public_key, subscribe_public_key
+        RETURNING authentication_public_key, subscribe_public_key, topic
     ";
     let start = Instant::now();
     let result = sqlx::query_as::<Postgres, ProjectWithPublicKeys>(query)

--- a/src/services/public_http_server/handlers/subscribe_topic.rs
+++ b/src/services/public_http_server/handlers/subscribe_topic.rs
@@ -85,8 +85,11 @@ pub async fn handler(
         other => other.into(),
     })?;
 
-    info!("Subscribing to project topic: {topic}");
-    state.relay_ws_client.subscribe(topic).await?;
+    // Don't call subscribe if we are already subscribed in a previous request
+    if project.topic == topic.as_ref() {
+        info!("Subscribing to project topic: {topic}");
+        state.relay_ws_client.subscribe(topic).await?;
+    }
 
     Ok(Json(SubscribeTopicResponseData {
         authentication_key: project.authentication_public_key,


### PR DESCRIPTION
# Description

Noticed we can optimize this, if we determine that we updated instead of inserted, then we don't need to subscribe.

It would be possible to do this without returning `topic`, but this would involve mucking with the private/public keypairs and would probably incur additional overhead so decided not to do it.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
