### PR TITLE
fix: security audits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,39 +143,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-tungstenite"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0388bb7a400072bbb41ceb75d65c3baefb2ea99672fa22e85278452cd9b58b"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "native-tls",
- "pin-project-lite",
- "tokio",
- "tokio-native-tls",
- "tungstenite",
-]
-
-[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1028,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4939f9ed1444bd8c896d37f3090012fa6e7834fe84ef8c9daa166109515732f9"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -1278,12 +1251,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dotenvy"
@@ -1824,15 +1791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2403,8 +2361,6 @@ name = "notify-server"
 version = "0.13.9"
 dependencies = [
  "async-trait",
- "async-tungstenite",
- "atty",
  "aws-config",
  "aws-sdk-s3",
  "axum",
@@ -2419,7 +2375,7 @@ dependencies = [
  "data-encoding",
  "deadpool-redis",
  "derive_more",
- "dotenv",
+ "dotenvy",
  "ed25519-dalek 2.0.0",
  "envy",
  "futures",
@@ -2579,7 +2535,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2606,9 +2562,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.59"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2638,9 +2594,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.95"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",
@@ -3155,7 +3111,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=54ce4be#54ce4be941e69608885a087046d12da082ef8892"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?branch=fix/security-RUSTSEC-2023-0065#ba10629ce73be34bdba876fe5f6fe2beed321d5d"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3178,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=54ce4be#54ce4be941e69608885a087046d12da082ef8892"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?branch=fix/security-RUSTSEC-2023-0065#ba10629ce73be34bdba876fe5f6fe2beed321d5d"
 dependencies = [
  "bs58",
  "chrono",
@@ -4286,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -4455,13 +4411,13 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http 0.2.9",
  "httparse",
  "log",
@@ -4673,9 +4629,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4683,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -4710,9 +4666,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4720,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4733,9 +4689,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?branch=fix/security-RUSTSEC-2023-0065#ba10629ce73be34bdba876fe5f6fe2beed321d5d"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.23.2#167c0569e838084f77a93c7a3f08ff5fb0894225"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?branch=fix/security-RUSTSEC-2023-0065#ba10629ce73be34bdba876fe5f6fe2beed321d5d"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.23.2#167c0569e838084f77a93c7a3f08ff5fb0894225"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ derive_more = "0.99.17"
 futures = "0.3.26"
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", version = "0.23.2", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", version = "0.23.2" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.23.2", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.23.2" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bson = "0.0.1"
 
 # Env Vars
-dotenv = "0.15"
+dotenvy = "0.15"
 envy = "0.4"
 
 # Metrics & Traces
@@ -37,7 +37,6 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.19"
-atty = "0.2"
 
 
 # Analytics
@@ -60,7 +59,7 @@ thiserror = "1.0"
 async-trait = "0.1"
 tokio-stream = "0.1.11"
 regex = "1.7.1"
-tungstenite = { version = "0.18.0", features = ["native-tls"] }
+tungstenite = { version = "0.20", features = ["native-tls"] }
 url = "2.3.1"
 sha256 = "1.1.1"
 chacha20poly1305 = "0.10.1"
@@ -73,14 +72,10 @@ data-encoding = "2.3.3"
 chrono = { version = "0.4.23", features = ["serde"] }
 derive_more = "0.99.17"
 futures = "0.3.26"
-async-tungstenite = { version = "0.20.0", features = [
-    "tokio",
-    "tokio-native-tls",
-] }
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "54ce4be", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "54ce4be" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", branch = "fix/security-RUSTSEC-2023-0065", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", branch = "fix/security-RUSTSEC-2023-0065" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ derive_more = "0.99.17"
 futures = "0.3.26"
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", branch = "fix/security-RUSTSEC-2023-0065", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", branch = "fix/security-RUSTSEC-2023-0065" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", version = "0.23.2", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", version = "0.23.2" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -1,7 +1,7 @@
 use {
     super::Configuration,
     crate::error::Result,
-    dotenv::dotenv,
+    dotenvy::dotenv,
     relay_rpc::domain::ProjectId,
     serde::Deserialize,
     std::net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -98,7 +98,7 @@ pub fn get_configuration() -> Result<Configuration> {
     Ok(config)
 }
 
-fn load_dot_env() -> dotenv::Result<()> {
+fn load_dot_env() -> dotenvy::Result<()> {
     match dotenv() {
         Ok(_) => Ok(()),
         Err(e) if e.not_found() => Ok(()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Failed to load .env {0}")]
-    DotEnv(#[from] dotenv::Error),
+    DotEnvy(#[from] dotenvy::Error),
 
     #[error("Failed to load configuration from environment {0}")]
     EnvConfiguration(#[from] envy::Error),


### PR DESCRIPTION
# Description

Fixes `cargo audit`. Only remaining issue is `openssl` but there is no fix version:

```
Crate:     rsa
Version:   0.9.3
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Severity:  7.4 (high)
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.9.3
└── sqlx-mysql 0.7.2
    ├── sqlx-macros-core 0.7.2
    │   └── sqlx-macros 0.7.2
    │       └── sqlx 0.7.2
    │           └── notify-server 0.13.9
    └── sqlx 0.7.2

error: 1 vulnerability found!
```

Work performed:

- Switch `dotenv` with unmaintained warning to `dotenvy`
- Remove `atty` with security warning, not used
- Remove unused `async-tungstenite`; version needed to be bumped alongside `tungstenite`
- `cargo update openssl crc-catalog wasm-bindgen`

Remaining work:

- [x] Merge https://github.com/WalletConnect/WalletConnectRust/pull/49
- [ ] Update ref here to use merged version

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
