### PR TITLE
chore(monitoring): fixing worker errors counter panel and add an alert

### DIFF
--- a/terraform/monitoring/panels/app/publishing_workers_errors.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_errors.libsonnet
@@ -11,9 +11,30 @@ local targets   = grafana.targets;
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)
+
+    .setAlert(vars.environment, grafana.alert.new(
+      namespace     = vars.namespace,
+      name          = '%(env)s - Notify publisher worker task error' % { env: vars.environment },
+      message       = '%(env)s - Notify publisher worker task error' % { env: vars.environment },
+      notifications = vars.notifications,
+      noDataState   = 'no_data',
+      period        = '0m',
+      conditions    = [
+        grafana.alertCondition.new(
+          evaluatorParams = [ 0 ],
+          evaluatorType   = 'gt',
+          operatorType    = 'or',
+          queryRefId      = 'PublishingWorkersErrors',
+          queryTimeStart  = '1m',
+          queryTimeEnd    = 'now',
+          reducerType     = grafana.alert_reducers.Avg
+        ),
+      ],
+    ))
+
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(publishing_workers_errors_total{}[$__rate_interval]))',
-      refId       = "availability",
+      expr        = 'sum(rate(publishing_workers_errors_total{}[$__rate_interval])) or vector(0)',
+      refId       = 'PublishingWorkersErrors',
     ))
 }


### PR DESCRIPTION
# Description

This PR changes the worker errors counter Grafana panel to show `0` instead of `No data` when no errors are recorded.
Also, this PR adds an alert when the error occurs.

Resolves #216 

## How Has This Been Tested?

Put the updated query into the Grafana panel and click the `run query`. 
The updated graph shows 0 instead of `No data`.

<img width="1033" alt="errors_graf" src="https://github.com/WalletConnect/notify-server/assets/11191291/5c98c35f-c436-44b4-85b5-4a2df0e83c7a">

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
