### PR TITLE
fix: run `CD` phase of dispatched deploy when only infra is selected

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -69,6 +69,7 @@ jobs:
     name: CD
     uses: ./.github/workflows/sub-cd.yml
     needs: [ select_version ]
+    if: ${{ always() && !cancelled() && !failure() }}
     secrets: inherit
     with:
       deploy-infra: ${{ inputs.deploy-infra }}


### PR DESCRIPTION
# Description

Due to the chain of dependencies, the CD step was not run when only deploying infra.
This should fix the issue.

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
