### PR TITLE
fix: add x-request-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,9 +4272,11 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.7.0", fe
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.6", features = ["json", "headers"] }
 tower = "0.4"
-tower-http = { version = "0.3", features = ["trace", "cors"] }
+tower-http = { version = "0.3", features = ["trace", "cors", "request-id", "util"] }
 hyper = "0.14"
 
 # Seralisation

--- a/src/services/public_http_server/mod.rs
+++ b/src/services/public_http_server/mod.rs
@@ -12,7 +12,9 @@ use {
     tower::ServiceBuilder,
     tower_http::{
         cors::{Any, CorsLayer},
+        request_id::MakeRequestUuid,
         trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
+        ServiceBuilderExt,
     },
     tracing::{info, Level},
     wc::geoip::{
@@ -31,6 +33,7 @@ pub async fn start(
     geoip_resolver: Option<Arc<MaxMindResolver>>,
 ) -> Result<(), hyper::Error> {
     let global_middleware = ServiceBuilder::new()
+        .set_x_request_id(MakeRequestUuid)
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(
@@ -45,6 +48,7 @@ pub async fn start(
                         .include_headers(true),
                 ),
         )
+        .propagate_x_request_id()
         .layer(
             // TODO test
             CorsLayer::new()


### PR DESCRIPTION
# Description

Adds `x-request-id` header span to make it easier to follow requests. [Context](https://github.com/WalletConnect/blockchain-api/commit/ab0a84a1a2a14230f189549fb3cfe1df9dbaec26#r134832094).

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
