### PR TITLE
fix: update the name of the `datalake` state source.

### DIFF
--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -13,7 +13,7 @@ data "terraform_remote_state" "datalake" {
   config = {
     organization = "wallet-connect"
     workspaces = {
-      name = "data-lake-${local.stage == "dev" ? "staging" : local.stage}"
+      name = "datalake-${local.stage == "dev" ? "staging" : local.stage}"
     }
   }
 }


### PR DESCRIPTION
# Description

The `data-lake` workspace has been renamed to `datalake` on TFC, which breaks TF operations.
This updated the name of the data source to reflect those changes.

## How Has This Been Tested?

TF plan.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
