### PR TITLE
feat: history sent_at

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -788,6 +788,7 @@ pub async fn delete_expired_subscription_watchers(
 #[derive(Debug, FromRow, Clone, Serialize, Deserialize)]
 pub struct Notification {
     pub id: Uuid,
+    pub sent_at: i64,
     pub r#type: Uuid,
     pub title: String,
     pub body: String,
@@ -844,7 +845,8 @@ pub async fn get_notifications_for_subscriber(
     let query = &format!(
         "
         SELECT
-            subscriber_notification.id as id,
+            subscriber_notification.id AS id,
+            CAST(EXTRACT(EPOCH FROM subscriber_notification.created_at AT TIME ZONE 'UTC') * 1000 AS int8) AS sent_at,
             notification.type,
             notification.title,
             notification.body,

--- a/src/notify_message.rs
+++ b/src/notify_message.rs
@@ -59,6 +59,7 @@ pub struct NotifyMessage {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, FromRow)]
 pub struct JwtNotification {
     pub id: Uuid,
+    pub sent_at: i64,
     pub r#type: Uuid,
     pub title: String,
     pub body: String,

--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -299,6 +299,7 @@ async fn process_notification(
             message_auth: sign_message(
                 Arc::new(JwtNotification {
                     id: notification.subscriber_notification,
+                    sent_at: notification.notification_created_at.timestamp_millis(),
                     r#type: notification.notification_type,
                     title: notification.notification_title.clone(),
                     body: notification.notification_body.clone(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4520,6 +4520,7 @@ async fn e2e_get_notifications_has_one(notify_server: &NotifyServerContext) {
         accounts: vec![account.clone()],
     };
 
+    let before_notification_sent = Utc::now();
     assert_successful_response(
         reqwest::Client::new()
             .post(
@@ -4535,6 +4536,7 @@ async fn e2e_get_notifications_has_one(notify_server: &NotifyServerContext) {
             .unwrap(),
     )
     .await;
+    let after_notification_sent = Utc::now();
 
     let result = get_notifications(
         &relay_ws_client,
@@ -4557,6 +4559,9 @@ async fn e2e_get_notifications_has_one(notify_server: &NotifyServerContext) {
     assert_eq!(notification.r#type, gotten_notification.r#type);
     assert_eq!(notification.title, gotten_notification.title);
     assert_eq!(notification.body, gotten_notification.body);
+
+    assert!(gotten_notification.sent_at >= before_notification_sent.timestamp_millis());
+    assert!(gotten_notification.sent_at <= after_notification_sent.timestamp_millis());
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description

Adds `sent_at` field as per the [specs](https://github.com/WalletConnect/walletconnect-specs/pull/183#pullrequestreview-1811112546)

## How Has This Been Tested?

Integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
