### PR TITLE
fix: history order

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -829,14 +829,11 @@ pub async fn get_notifications_for_subscriber(
     let after_clause = if after.is_some() {
         "
         AND (
+            (SELECT created_at FROM subscriber_notification WHERE id=$3),
+            $3
+        ) > (
             subscriber_notification.created_at,
             subscriber_notification.id
-        ) > (
-            SELECT
-                subscriber_notification.created_at,
-                subscriber_notification.id
-            FROM subscriber_notification
-            WHERE id=$3
         )
         "
     } else {
@@ -858,9 +855,8 @@ pub async fn get_notifications_for_subscriber(
             subscriber_notification.subscriber=$1
             {after_clause}
         ORDER BY
-            subscriber_notification.created_at,
-            subscriber_notification.id
-            DESC
+            subscriber_notification.created_at DESC,
+            subscriber_notification.id DESC
         LIMIT $2
         "
     );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4784,7 +4784,7 @@ async fn get_notifications_4() {
     assert!(!result.has_more);
 
     for (n1, n2) in result.notifications.iter().tuple_windows() {
-        assert!(n1.sent_at <= n2.sent_at);
+        assert!(n1.sent_at >= n2.sent_at);
     }
 
     let mut gotten_ids = HashSet::with_capacity(7);
@@ -5007,7 +5007,7 @@ async fn get_notifications_6() {
     assert!(!second_page.has_more);
 
     assert!(
-        first_page.notifications.last().unwrap().sent_at <= second_page.notifications[0].sent_at
+        first_page.notifications.last().unwrap().sent_at >= second_page.notifications[0].sent_at
     );
 
     for notification in second_page.notifications {
@@ -5105,13 +5105,11 @@ async fn get_notifications_7() {
     assert_eq!(first_page.notifications.len(), limit);
     assert!(first_page.has_more);
 
-    for (notification, expected_title) in first_page
-        .notifications
-        .iter()
-        .zip(notification_titles[0..limit].iter())
-    {
-        assert_eq!(&notification.title, expected_title);
-    }
+    assert_eq!(&first_page.notifications[0].title, notification_titles[6]);
+    assert_eq!(&first_page.notifications[1].title, notification_titles[5]);
+    assert_eq!(&first_page.notifications[2].title, notification_titles[4]);
+    assert_eq!(&first_page.notifications[3].title, notification_titles[3]);
+    assert_eq!(&first_page.notifications[4].title, notification_titles[2]);
 
     let second_page = get_notifications_for_subscriber(
         subscriber,
@@ -5128,8 +5126,8 @@ async fn get_notifications_7() {
     assert_eq!(second_page.notifications.len(), 2);
     assert!(!second_page.has_more);
 
-    assert_eq!(&second_page.notifications[0].title, notification_titles[5]);
-    assert_eq!(&second_page.notifications[1].title, notification_titles[6]);
+    assert_eq!(&second_page.notifications[0].title, notification_titles[1]);
+    assert_eq!(&second_page.notifications[1].title, notification_titles[0]);
 
     // TODO apply HashMap approach for all of these?
 }
@@ -5216,13 +5214,11 @@ async fn different_created_at() {
     assert_eq!(first_page.notifications.len(), limit);
     assert!(first_page.has_more);
 
-    for (notification, expected_title) in first_page
-        .notifications
-        .iter()
-        .zip(notification_titles[0..limit].iter())
-    {
-        assert_eq!(&notification.title, expected_title);
-    }
+    assert_eq!(&first_page.notifications[0].title, notification_titles[6]);
+    assert_eq!(&first_page.notifications[1].title, notification_titles[5]);
+    assert_eq!(&first_page.notifications[2].title, notification_titles[4]);
+    assert_eq!(&first_page.notifications[3].title, notification_titles[3]);
+    assert_eq!(&first_page.notifications[4].title, notification_titles[2]);
 
     let second_page = get_notifications_for_subscriber(
         subscriber,
@@ -5239,8 +5235,8 @@ async fn different_created_at() {
     assert_eq!(second_page.notifications.len(), 2);
     assert!(!second_page.has_more);
 
-    assert_eq!(&second_page.notifications[0].title, notification_titles[5]);
-    assert_eq!(&second_page.notifications[1].title, notification_titles[6]);
+    assert_eq!(&second_page.notifications[0].title, notification_titles[1]);
+    assert_eq!(&second_page.notifications[1].title, notification_titles[0]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description

Actually reverses the order of get notifications so that the most recently sent notification is ordered first in the list.

## How Has This Been Tested?

Updated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
