### PR TITLE
feat: chain agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ just devloop
 just run-storage-docker test-integration
 ```
 
+Run a specific test:
+
+```bash
+just test=test_one_project test-integration
+```
+
 ```bash
 just stop-storage-docker
 ```

--- a/justfile
+++ b/justfile
@@ -27,9 +27,10 @@ test-all:
   @echo '==> Testing project (all features)'
   RUST_BACKTRACE=1 cargo test --all-features --lib --bins
 
+test := ""
 test-integration:
   @echo '==> Testing integration'
-  RUST_BACKTRACE=1 ANSI_LOGS=true cargo test --test integration
+  RUST_BACKTRACE=1 ANSI_LOGS=true cargo test --test integration -- {{test}}
 
 # Clean build artifacts
 clean:

--- a/migrations/20240111200929_unique_account_address.sql
+++ b/migrations/20240111200929_unique_account_address.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION get_address_lower(account_id text)
+RETURNS text AS $$
+BEGIN
+    RETURN lower(split_part(account_id, ':', 3));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+ALTER TABLE subscriber DROP CONSTRAINT subscriber_project_account_key;
+CREATE INDEX subscriber_address ON subscriber (get_address_lower(account));
+CREATE UNIQUE INDEX subscriber_project_account_key ON subscriber (project, get_address_lower(account));

--- a/migrations/20240111200929_unique_account_address.sql
+++ b/migrations/20240111200929_unique_account_address.sql
@@ -5,6 +5,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-ALTER TABLE subscriber DROP CONSTRAINT subscriber_project_account_key;
 CREATE INDEX subscriber_address ON subscriber (get_address_lower(account));
+
+WITH duplicates AS (
+    SELECT id,
+        ROW_NUMBER() OVER (
+            PARTITION BY get_address_lower(account)
+            -- ORDER BY some_criteria
+        ) as rn
+    FROM subscriber
+)
+DELETE FROM subscriber WHERE id IN (SELECT id FROM duplicates WHERE rn > 1);
+
+ALTER TABLE subscriber DROP CONSTRAINT subscriber_project_account_key;
 CREATE UNIQUE INDEX subscriber_project_account_key ON subscriber (project, get_address_lower(account));

--- a/migrations/20240111200929_unique_account_address.sql
+++ b/migrations/20240111200929_unique_account_address.sql
@@ -10,7 +10,7 @@ CREATE INDEX subscriber_address ON subscriber (get_address_lower(account));
 WITH duplicates AS (
     SELECT id,
         ROW_NUMBER() OVER (
-            PARTITION BY get_address_lower(account)
+            PARTITION BY project, get_address_lower(account)
             -- ORDER BY some_criteria
         ) as rn
     FROM subscriber

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -487,6 +487,9 @@ pub enum AuthError {
     #[error("CACAO iss is not a did:pkh: {0}")]
     CacaoIssNotDidPkh(DidError),
 
+    #[error("Account namespace not supported.")]
+    AccountNamespaceNotSupported,
+
     #[error("CACAO has wrong iss")]
     CacaoWrongIdentityKey,
 
@@ -628,6 +631,15 @@ pub async fn verify_identity(
         metrics.keys_server_request(start, &source);
     }
 
+    let account = AccountId::from_did_pkh(&cacao.p.iss).map_err(AuthError::CacaoIssNotDidPkh)?;
+
+    // Protect our state from unexpected address formats. Important for cross-chain equivalence detection logic
+    // Cacao verification should only support eip155 verification anyway
+    // TODO move this protection into the creation of AccountId itself
+    if !is_eip155_account(&account) {
+        return Err(AuthError::AccountNamespaceNotSupported)?;
+    }
+
     let always_true = cacao.verify().map_err(AuthError::CacaoValidation)?;
     assert!(always_true);
 
@@ -650,8 +662,6 @@ pub async fn verify_identity(
     if cacao.p.iss != sub {
         Err(AuthError::CacaoAccountMismatch)?;
     }
-
-    let account = AccountId::from_did_pkh(&cacao.p.iss).map_err(AuthError::CacaoIssNotDidPkh)?;
 
     if let Some(nbf) = cacao.p.nbf {
         let nbf = DateTime::parse_from_rfc3339(&nbf)?;
@@ -781,6 +791,11 @@ impl<'a> Deserialize<'a> for DidWeb {
     }
 }
 
+fn is_eip155_account(account: &AccountId) -> bool {
+    let pattern = regex::Regex::new(r"^eip155:\d+:0x[0-9a-fA-F]{40}$").unwrap();
+    pattern.is_match(account.as_ref())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -844,5 +859,64 @@ mod test {
             .unwrap(),
             AuthorizedApp::Limited("app.example.com".to_owned())
         );
+    }
+
+    #[test]
+    fn test_is_eip155_account() {
+        assert!(is_eip155_account(
+            &"eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(is_eip155_account(
+            &"eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(is_eip155_account(
+            &"eip155:12:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"eip156:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"eip15:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"eip155:12:62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d00"
+                .to_string()
+                .into()
+        ));
+        assert!(!is_eip155_account(
+            &"eeip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
+                .to_string()
+                .into()
+        ));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -172,6 +172,9 @@ pub enum Error {
     #[error(transparent)]
     AppNotAuthorized(#[from] CheckAppAuthorizationError),
 
+    #[error("The account authenticated cannot control this subscription")]
+    AccountNotAuthorized,
+
     #[error("sqlx error: {0}")]
     SqlxError(#[from] sqlx::error::Error),
 

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -717,6 +717,8 @@ pub async fn upsert_subscription_watcher(
 
 #[derive(Debug, FromRow)]
 pub struct SubscriptionWatcherQuery {
+    #[sqlx(try_from = "String")]
+    pub account: AccountId,
     pub project: Option<Uuid>,
     pub did_key: String,
     pub sym_key: String,
@@ -730,7 +732,7 @@ pub async fn get_subscription_watchers_for_account_by_app_or_all_app(
     metrics: Option<&Metrics>,
 ) -> Result<Vec<SubscriptionWatcherQuery>, sqlx::error::Error> {
     let query = "
-        SELECT project, did_key, sym_key
+        SELECT account, project, did_key, sym_key
         FROM subscription_watcher
         LEFT JOIN project ON project.id=subscription_watcher.project
         WHERE expiry > now()

--- a/src/services/websocket_server/handlers/notify_delete.rs
+++ b/src/services/websocket_server/handlers/notify_delete.rs
@@ -26,7 +26,7 @@ use {
         },
         state::{AppState, WebhookNotificationEvent},
         types::{Envelope, EnvelopeType0},
-        utils::topic_from_key,
+        utils::{is_same_address, topic_from_key},
         Result,
     },
     base64::Engine,
@@ -108,6 +108,10 @@ pub async fn handle(msg: PublishedMessage, state: &AppState, client: &Client) ->
             }
         }
 
+        if !is_same_address(&account, &subscriber.account) {
+            Err(Error::AccountNotAuthorized)?;
+        }
+
         (account, domain)
     };
 
@@ -130,7 +134,7 @@ pub async fn handle(msg: PublishedMessage, state: &AppState, client: &Client) ->
         project_pk: project.id,
         project_id: project.project_id,
         pk: subscriber.id,
-        account: account.clone(),
+        account: subscriber.account, // Use a consistent account for analytics rather than the per-request one
         updated_by_iss: request_auth.shared_claims.iss.clone().into(),
         updated_by_domain: siwe_domain,
         method: NotifyClientMethod::Unsubscribe,

--- a/src/services/websocket_server/handlers/notify_delete.rs
+++ b/src/services/websocket_server/handlers/notify_delete.rs
@@ -196,7 +196,6 @@ pub async fn handle(msg: PublishedMessage, state: &AppState, client: &Client) ->
 
     send_to_subscription_watchers(
         watchers_with_subscriptions,
-        &account,
         &state.notify_keys.authentication_secret,
         &state.notify_keys.authentication_client_id,
         &state.relay_http_client.clone(),

--- a/src/services/websocket_server/handlers/notify_subscribe.rs
+++ b/src/services/websocket_server/handlers/notify_subscribe.rs
@@ -304,7 +304,6 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
 
     send_to_subscription_watchers(
         watchers_with_subscriptions,
-        &account,
         &state.notify_keys.authentication_secret,
         &state.notify_keys.authentication_client_id,
         &state.relay_http_client.clone(),

--- a/src/services/websocket_server/handlers/notify_subscribe.rs
+++ b/src/services/websocket_server/handlers/notify_subscribe.rs
@@ -151,7 +151,7 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
     );
 
     info!("Timing: Upserting subscriber");
-    let subscriber_id = upsert_subscriber(
+    let subscriber = upsert_subscriber(
         project.id,
         account.clone(),
         scope.clone(),
@@ -183,8 +183,8 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
     state.analytics.client(SubscriberUpdateParams {
         project_pk: project.id,
         project_id,
-        pk: subscriber_id,
-        account: account.clone(),
+        pk: subscriber.id,
+        account: subscriber.account, // Use a consistent account for analytics rather than the per-request one
         updated_by_iss: request_iss_client_id.to_did_key().into(),
         updated_by_domain: siwe_domain,
         method: NotifyClientMethod::Subscribe,
@@ -290,7 +290,7 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
 
             upsert_subscriber_notifications(
                 notification.id,
-                &[subscriber_id],
+                &[subscriber.id],
                 &state.postgres,
                 state.metrics.as_ref(),
             )

--- a/src/services/websocket_server/handlers/notify_update.rs
+++ b/src/services/websocket_server/handlers/notify_update.rs
@@ -198,7 +198,6 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
 
     send_to_subscription_watchers(
         watchers_with_subscriptions,
-        &account,
         &state.notify_keys.authentication_secret,
         &state.notify_keys.authentication_client_id,
         &state.relay_http_client.clone(),

--- a/src/services/websocket_server/handlers/notify_update.rs
+++ b/src/services/websocket_server/handlers/notify_update.rs
@@ -24,7 +24,7 @@ use {
         },
         state::AppState,
         types::{parse_scope, Envelope, EnvelopeType0},
-        utils::topic_from_key,
+        utils::{is_same_address, topic_from_key},
         Result,
     },
     base64::Engine,
@@ -104,6 +104,10 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
             }
         }
 
+        if !is_same_address(&account, &subscriber.account) {
+            Err(Error::AccountNotAuthorized)?;
+        }
+
         (account, domain)
     };
 
@@ -111,8 +115,7 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
     let new_scope = parse_scope(&request_auth.scp)?;
 
     let subscriber = update_subscriber(
-        project.id,
-        account.clone(),
+        subscriber.id,
         new_scope.clone(),
         &state.postgres,
         state.metrics.as_ref(),
@@ -132,7 +135,7 @@ pub async fn handle(msg: PublishedMessage, state: &AppState) -> Result<()> {
         project_pk: project.id,
         project_id: project.project_id,
         pk: subscriber.id,
-        account: account.clone(),
+        account: subscriber.account, // Use a consistent account for analytics rather than the per-request one
         updated_by_iss: request_auth.shared_claims.iss.clone().into(),
         updated_by_domain: siwe_domain,
         method: NotifyClientMethod::Update,

--- a/src/services/websocket_server/handlers/notify_watch_subscriptions.rs
+++ b/src/services/websocket_server/handlers/notify_watch_subscriptions.rs
@@ -322,7 +322,6 @@ pub async fn prepare_subscription_watchers(
 
 pub async fn send_to_subscription_watchers(
     watchers_with_subscriptions: Vec<(SubscriptionWatcherQuery, Vec<NotifyServerSubscription>)>,
-    account: &AccountId,
     authentication_secret: &ed25519_dalek::SigningKey,
     authentication_client_id: &DecodedClientId,
     http_client: &relay_client::http::Client,
@@ -335,7 +334,7 @@ pub async fn send_to_subscription_watchers(
         );
         send(
             subscriptions,
-            account,
+            &watcher.account,
             watcher.did_key.clone(),
             &watcher.sym_key,
             authentication_secret,

--- a/src/services/websocket_server/handlers/notify_watch_subscriptions.rs
+++ b/src/services/websocket_server/handlers/notify_watch_subscriptions.rs
@@ -333,7 +333,7 @@ pub async fn send_to_subscription_watchers(
             watcher.did_key
         );
         send(
-            subscriptions,
+            &subscriptions,
             &watcher.account,
             watcher.did_key.clone(),
             &watcher.sym_key,
@@ -354,7 +354,7 @@ pub async fn send_to_subscription_watchers(
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, fields(account = %account, aud = %aud, subscriptions_count = %subscriptions.len()))]
 async fn send(
-    subscriptions: Vec<NotifyServerSubscription>,
+    subscriptions: &[NotifyServerSubscription],
     account: &AccountId,
     aud: String,
     sym_key: &str,
@@ -374,7 +374,13 @@ async fn send(
             mjv: "1".to_owned(),
         },
         sub: account.to_did_pkh(),
-        sbs: subscriptions,
+        sbs: subscriptions
+            .iter()
+            .map(|sub| NotifyServerSubscription {
+                account: account.clone(),
+                ..sub.clone()
+            })
+            .collect(),
     };
     let auth = sign_jwt(response_message, authentication_secret)?;
     let request = NotifyRequest::new(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
-use relay_rpc::domain::{DecodedClientId, Topic};
+use {
+    crate::model::types::AccountId,
+    relay_rpc::domain::{DecodedClientId, Topic},
+};
 
 // TODO consider using the key object directly instead of a byte slice
 pub fn topic_from_key(key: &[u8]) -> Topic {
@@ -10,4 +13,17 @@ pub fn get_client_id(verifying_key: &ed25519_dalek::VerifyingKey) -> DecodedClie
     // See: https://github.com/WalletConnect/WalletConnectRust/issues/53
     // DecodedClientId::from_key(verifying_key)
     DecodedClientId(verifying_key.to_bytes())
+}
+
+pub fn get_address_from_account(account: &AccountId) -> &str {
+    let s = account.as_ref();
+    let known_skippable_prefix_len = "eip155:1".len();
+    let i = s[known_skippable_prefix_len..]
+        .find(':')
+        .expect("AccountId should have already been validated to be eip155");
+    &s[known_skippable_prefix_len + i + 1..]
+}
+
+pub fn is_same_address(account1: &AccountId, account2: &AccountId) -> bool {
+    get_address_from_account(account1).eq_ignore_ascii_case(get_address_from_account(account2))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7478,6 +7478,3 @@ async fn no_watcher_returns_only_app_subscriptions(notify_server: &NotifyServerC
 
 // TODO test subscribing from 2 accounts results in 1 subscription
 // TODO test having 2 subscriptions prior to migration will result in 1 subscription
-
-// TODO test that mjv=0 gives you all app notifications
-// TODO test all apps notifications?

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7235,6 +7235,7 @@ async fn same_address_different_chain_watch_subscriptions(notify_server: &Notify
     assert_eq!(subs.len(), 1);
     let sub1 = &subs[0];
     assert_eq!(sub1.scope, notification_types);
+    assert_eq!(sub1.account, account1);
     let subs = accept_watch_subscriptions_changed(
         &notify_server_client_id,
         &identity_key_details2,
@@ -7247,6 +7248,7 @@ async fn same_address_different_chain_watch_subscriptions(notify_server: &Notify
     assert_eq!(subs.len(), 1);
     let sub2 = &subs[0];
     assert_eq!(sub2.scope, notification_types);
+    assert_eq!(sub1.account, account1);
 
     assert_eq!(sub1.sym_key, sub2.sym_key);
     let notify_key = decode_key(&sub2.sym_key).unwrap();
@@ -7279,6 +7281,7 @@ async fn same_address_different_chain_watch_subscriptions(notify_server: &Notify
     .await;
     assert_eq!(subs.len(), 1);
     assert_eq!(subs[0].scope, notification_types);
+    assert_eq!(subs[0].account, account1);
     let subs = accept_watch_subscriptions_changed(
         &notify_server_client_id,
         &identity_key_details2,
@@ -7290,6 +7293,7 @@ async fn same_address_different_chain_watch_subscriptions(notify_server: &Notify
     .await;
     assert_eq!(subs.len(), 1);
     assert_eq!(subs[0].scope, notification_types);
+    assert_eq!(subs[0].account, account2);
 }
 
 #[test_context(NotifyServerContext)]
@@ -7398,4 +7402,4 @@ async fn same_address_different_chain_notify(notify_server: &NotifyServerContext
 
 // TODO test that mjv=0 gives you all app notifications
 // TODO test all apps notifications?
-// TODO test watch subscriptions subs account=same for request
+// TODO test no watchSubscriptions gives you 1 app for sbs response

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2792,6 +2792,7 @@ async fn subscribe_with_mjv(
         auth.shared_claims.aud,
         identity_key_details.client_id.to_did_key()
     );
+    assert_eq!(auth.sub, account.to_did_pkh());
 
     auth.sbs
 }
@@ -2962,6 +2963,10 @@ async fn watch_subscriptions(
         auth.shared_claims.aud,
         identity_key_details.client_id.to_did_key()
     );
+    assert!(is_same_address(
+        &AccountId::from_did_pkh(&auth.sub).unwrap(),
+        account
+    ));
 
     (auth.sbs, response_topic_key, client_id)
 }
@@ -3044,6 +3049,10 @@ async fn accept_watch_subscriptions_changed(
         auth.shared_claims.aud,
         identity_key_details.client_id.to_did_key()
     );
+    assert!(is_same_address(
+        &AccountId::from_did_pkh(&auth.sub).unwrap(),
+        account
+    ));
 
     publish_subscriptions_changed_response(
         relay_ws_client,
@@ -3133,6 +3142,10 @@ async fn accept_notify_message(
     assert!(claims.exp > chrono::Utc::now().timestamp() - JWT_LEEWAY); // TODO remove leeway
     assert_eq!(claims.app.as_ref(), app_domain.domain()); // bug: https://github.com/WalletConnect/notify-server/issues/251
     assert_eq!(claims.act, NOTIFY_MESSAGE_ACT);
+    assert!(is_same_address(
+        &AccountId::from_did_pkh(&claims.sub).unwrap(),
+        account
+    ));
 
     (request.id, claims)
 }
@@ -3310,6 +3323,7 @@ async fn update_with_mjv(
         identity_key_details.client_id.to_did_key()
     );
     assert_eq!(&auth.app, app);
+    assert_eq!(auth.sub, account.to_did_pkh());
 
     auth.sbs
 }
@@ -3443,6 +3457,7 @@ async fn delete_with_mjv(
         identity_key_details.client_id.to_did_key()
     );
     assert_eq!(&auth.app, app);
+    assert_eq!(auth.sub, account.to_did_pkh());
 
     auth.sbs
 }
@@ -3535,6 +3550,7 @@ async fn get_notifications(
         identity_key_details.client_id.to_did_key()
     );
     assert_eq!(&auth.app, app);
+    assert_eq!(auth.sub, account.to_did_pkh());
 
     let value = serde_json::to_value(&auth).unwrap();
     assert!(value.get("sub").is_some());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2963,10 +2963,7 @@ async fn watch_subscriptions(
         auth.shared_claims.aud,
         identity_key_details.client_id.to_did_key()
     );
-    assert!(is_same_address(
-        &AccountId::from_did_pkh(&auth.sub).unwrap(),
-        account
-    ));
+    assert_eq!(auth.sub, account.to_did_pkh());
 
     (auth.sbs, response_topic_key, client_id)
 }
@@ -3049,10 +3046,7 @@ async fn accept_watch_subscriptions_changed(
         auth.shared_claims.aud,
         identity_key_details.client_id.to_did_key()
     );
-    assert!(is_same_address(
-        &AccountId::from_did_pkh(&auth.sub).unwrap(),
-        account
-    ));
+    assert_eq!(auth.sub, account.to_did_pkh());
 
     publish_subscriptions_changed_response(
         relay_ws_client,
@@ -7401,3 +7395,7 @@ async fn same_address_different_chain_notify(notify_server: &NotifyServerContext
 
 // TODO test subscribing from 2 accounts results in 1 subscription
 // TODO test having 2 subscriptions prior to migration will result in 1 subscription
+
+// TODO test that mjv=0 gives you all app notifications
+// TODO test all apps notifications?
+// TODO test watch subscriptions subs account=same for request

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -91,7 +91,7 @@ pub fn verify_jwt(jwt: &str, key: &VerifyingKey) -> notify_server::error::Result
     }
 }
 
-pub fn generate_account() -> (SigningKey, AccountId) {
+pub fn generate_eoa() -> (SigningKey, String) {
     let account_signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
     let address = &Keccak256::default()
         .chain_update(
@@ -101,7 +101,17 @@ pub fn generate_account() -> (SigningKey, AccountId) {
                 .as_bytes()[1..],
         )
         .finalize()[12..];
-    let account = format!("eip155:1:0x{}", hex::encode(address)).into();
+    let address = format!("0x{}", hex::encode(address));
+    (account_signing_key, address)
+}
+
+pub fn format_eip155_account(chain_id: u32, address: &str) -> AccountId {
+    format!("eip155:{chain_id}:{address}").into()
+}
+
+pub fn generate_account() -> (SigningKey, AccountId) {
+    let (account_signing_key, address) = generate_eoa();
+    let account = format_eip155_account(1, &address);
     (account_signing_key, account)
 }
 


### PR DESCRIPTION
# Description

- Implements behavior for treating any account the same as long as it has the same address. This works by using the `get_address_lower()` function when doing SQL queries.
  - An alternative approach is to migrate the database so that it only stores address and not the full account ID. While this would simplify queries and probably be simpler overall, I decided to keep the current format as this is a risky change overall and the chain info may be needed in the future (for example with smart contract support or namespace identification).
- For now assumes eip155 account IDs
  - Manually confirmed that all accounts are currently eip155
  - This is enforced going forward with `is_eip155_account()` in the `verify_identity()` function
- Implements migration to delete subscribers with the same address, prior to adding the new unique constraint. This keeps the subscription with the most notifications.
- Fix security issue where delete subscription requests do not verify that the account matches the looked up subscriber. Added explicit `is_same_address()` check. This was not a high-risk issue because it required already knowing the symmetric key of the topic, which is private information anyway.
  - Refactor `update_subscriber()` parameters to take subscriber ID instead of project and account, to simplify, improve performance, and reduce risk of security vulnerabilities (i.e. using the same subscriber that was looked up earlier in the function)
- Refactor `upsert_subscriber()` to also return `account` of the subscriber so that analytics can export a consistent account regardless of which account was used for the request

Resolves #265 

## How Has This Been Tested?

New automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
