### PR TITLE
fix: add Redis Grafana and bump scale

### DIFF
--- a/terraform/monitoring/README.md
+++ b/terraform/monitoring/README.md
@@ -35,6 +35,7 @@ Configure the Grafana dashboards for the application
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN of the monitoring role. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The notification channels to send alerts to |  <pre lang="json">list(any)</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_prometheus_endpoint"></a> [prometheus\_endpoint](#input\_prometheus\_endpoint) | The endpoint for the Prometheus server. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
+| <a name="input_redis_cluster_id"></a> [redis\_cluster\_id](#input\_redis\_cluster\_id) | The cluster ID of the Redis cluster. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 ## Outputs
 
 No outputs.

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -103,6 +103,12 @@ dashboard.new(
     panels.rds.database_connections(ds, vars)     { gridPos: pos._4 },
 
   //////////////////////////////////////////////////////////////////////////////
+  row.new('Redis'),
+    panels.redis.cpu(ds, vars)                    { gridPos: pos._3 },
+    panels.redis.memory(ds, vars)                 { gridPos: pos._3 },
+    panels.redis.swap_usage(ds, vars)             { gridPos: pos._3 },
+
+  //////////////////////////////////////////////////////////////////////////////
   row.new('Load Balancer'),
     panels.lb.active_connections(ds, vars)        { gridPos: pos._2 },
     panels.lb.requests(ds, vars)                  { gridPos: pos._2 },

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -23,6 +23,7 @@ local vars  = {
 
   ecs_service_name: std.extVar('ecs_service_name'),
   ecs_cluster_name: std.extVar('ecs_cluster_name'),
+  redis_cluster_id: std.extVar('redis_cluster_id'),
   load_balancer:    std.extVar('load_balancer'),
   target_group:     std.extVar('target_group'),
 };

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -13,6 +13,7 @@ data "jsonnet_file" "dashboard" {
 
     ecs_cluster_name = var.ecs_cluster_name
     ecs_service_name = var.ecs_service_name
+    redis_cluster_id = var.redis_cluster_id
     load_balancer    = var.load_balancer_arn
     target_group     = var.ecs_target_group_arn
   }

--- a/terraform/monitoring/panels/app/postgres_query_rate.libsonnet
+++ b/terraform/monitoring/panels/app/postgres_query_rate.libsonnet
@@ -22,4 +22,12 @@ local targets   = grafana.targets;
       exemplar      = true,
       refId         = 'PostgresQueryRate',
     ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(rate(postgres_queries_total[$__rate_interval]))',
+      legendFormat  = 'r{{aws_ecs_task_revision}}',
+      exemplar      = true,
+      refId         = 'TotalQueries',
+    ))
 }

--- a/terraform/monitoring/panels/app/postgres_query_rate.libsonnet
+++ b/terraform/monitoring/panels/app/postgres_query_rate.libsonnet
@@ -28,6 +28,6 @@ local targets   = grafana.targets;
       expr          = 'sum(rate(postgres_queries_total[$__rate_interval]))',
       legendFormat  = 'r{{aws_ecs_task_revision}}',
       exemplar      = true,
-      refId         = 'TotalQueries',
+      refId         = 'PostgresQueryRateTotal',
     ))
 }

--- a/terraform/monitoring/panels/app/relay_incoming_message_server_errors.libsonnet
+++ b/terraform/monitoring/panels/app/relay_incoming_message_server_errors.libsonnet
@@ -21,10 +21,10 @@ local targets   = grafana.targets;
       period        = '0m',
       conditions    = [
         grafana.alertCondition.new(
-          evaluatorParams = [ 0 ],
+          evaluatorParams = [ 25 ],
           evaluatorType   = 'gt',
           operatorType    = 'or',
-          queryRefId      = 'RelayIncomingMessagesServerErrors',
+          queryRefId      = 'RelayIncomingMessagesServerErrorsTotal',
           queryTimeStart  = '5m',
           queryTimeEnd    = 'now',
           reducerType     = grafana.alert_reducers.Avg
@@ -38,5 +38,13 @@ local targets   = grafana.targets;
       legendFormat  = '{{tag}} r{{aws_ecs_task_revision}}',
       exemplar      = true,
       refId         = 'RelayIncomingMessagesServerErrors',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(increase(relay_incoming_messages_total{status="server_error"}[$__rate_interval]))',
+      legendFormat  = 'r{{aws_ecs_task_revision}}',
+      exemplar      = true,
+      refId         = 'RelayIncomingMessagesServerErrorsTotal',
     ))
 }

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -1,6 +1,7 @@
 local panels = (import '../grafonnet-lib/defaults.libsonnet').panels;
 local docdb  = panels.aws.docdb;
 local ecs    = panels.aws.ecs;
+local redis  = panels.aws.redis;
 local units  = (import '../grafonnet-lib/utils/units.libsonnet');
 
 # Make sure `docdb_mem_threshold` is 10% of total DocumentDB memory as per AWS guidance:
@@ -47,6 +48,11 @@ local docdb_mem_threshold = units.size_bin(GiB = docdb_mem * 0.1);
     freeable_memory:       (import 'rds/freeable_memory.libsonnet'       ).new,
     volume_bytes_used:     (import 'rds/volume_bytes_used.libsonnet'     ).new,
     database_connections:  (import 'rds/database_connections.libsonnet'  ).new,
+  },
+  redis: {
+    cpu(ds, vars):            redis.cpu.panel(ds.cloudwatch, vars.namespace, vars.environment, vars.notifications, vars.redis_cluster_id),
+    memory(ds, vars):         redis.memory.panel(ds.cloudwatch, vars.namespace, vars.environment, vars.notifications, vars.redis_cluster_id),
+    swap_usage(ds, vars):     redis.swap_usage.panel(ds.cloudwatch, vars.namespace, vars.environment, vars.notifications, vars.redis_cluster_id),
   },
   lb: {
     active_connections:       (import 'lb/active_connections.libsonnet'         ).new,

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -28,6 +28,11 @@ variable "ecs_target_group_arn" {
   type        = string
 }
 
+variable "redis_cluster_id" {
+  description = "The cluster ID of the Redis cluster."
+  type        = string
+}
+
 variable "load_balancer_arn" {
   description = "The ARN of the load balancer."
   type        = string

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -35,7 +35,7 @@ module "ecs" {
   ecr_repository_url        = local.ecr_repository_url
   image_version             = var.image_version
   task_execution_role_name  = aws_iam_role.application_role.name
-  task_cpu                  = 8064 # 8192 - 128
+  task_cpu                  = 8064  # 8192 - 128
   task_memory               = 16256 # 16384-128
   autoscaling_desired_count = var.app_autoscaling_desired_count
   autoscaling_min_capacity  = var.app_autoscaling_min_capacity

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -35,8 +35,8 @@ module "ecs" {
   ecr_repository_url        = local.ecr_repository_url
   image_version             = var.image_version
   task_execution_role_name  = aws_iam_role.application_role.name
-  task_cpu                  = 8192
-  task_memory               = 16384
+  task_cpu                  = 8064 # 8192 - 128
+  task_memory               = 16256 # 16384-128
   autoscaling_desired_count = var.app_autoscaling_desired_count
   autoscaling_min_capacity  = var.app_autoscaling_min_capacity
   autoscaling_max_capacity  = var.app_autoscaling_max_capacity

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -35,8 +35,8 @@ module "ecs" {
   ecr_repository_url        = local.ecr_repository_url
   image_version             = var.image_version
   task_execution_role_name  = aws_iam_role.application_role.name
-  task_cpu                  = 512
-  task_memory               = 1024
+  task_cpu                  = 8192
+  task_memory               = 16384
   autoscaling_desired_count = var.app_autoscaling_desired_count
   autoscaling_min_capacity  = var.app_autoscaling_min_capacity
   autoscaling_max_capacity  = var.app_autoscaling_max_capacity

--- a/terraform/res_monitoring.tf
+++ b/terraform/res_monitoring.tf
@@ -10,5 +10,6 @@ module "monitoring" {
   ecs_cluster_name     = module.ecs.ecs_cluster_name
   ecs_service_name     = module.ecs.ecs_service_name
   ecs_target_group_arn = module.ecs.target_group_arn
+  redis_cluster_id     = module.redis.cluster_id
   load_balancer_arn    = module.ecs.load_balancer_arn_suffix
 }


### PR DESCRIPTION
# Description

Adds Grafana charts for Redis and bump scaling configuration to match current scale.

Resolves #281

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
