### PR TITLE
fix: temp boost watch subscriptions rate limit and JWT validity allowance

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -360,11 +360,11 @@ pub fn from_jwt<T: DeserializeOwned + GetSharedClaims>(jwt: &str) -> Result<T> {
 
     info!("iss: {}", claims.get_shared_claims().iss);
 
-    if claims.get_shared_claims().exp < Utc::now().timestamp().unsigned_abs() {
+    if claims.get_shared_claims().exp + 300 <= Utc::now().timestamp().unsigned_abs() {
         Err(AuthError::JwtExpired)?;
     }
 
-    if claims.get_shared_claims().iat > Utc::now().timestamp_millis().unsigned_abs() {
+    if Utc::now().timestamp_millis().unsigned_abs() < claims.get_shared_claims().iat - 300 {
         Err(AuthError::JwtNotYetValid)?;
     }
 

--- a/src/services/websocket_server/handlers/notify_watch_subscriptions.rs
+++ b/src/services/websocket_server/handlers/notify_watch_subscriptions.rs
@@ -202,9 +202,11 @@ pub async fn notify_watch_subscriptions_rate_limit(
             "notify-watch-subscriptions-{}",
             hex::encode(client_public_key.as_bytes())
         ),
-        100,
+        // 100,
+        1000,
         chrono::Duration::seconds(1),
-        1,
+        // 1,
+        100,
         clock,
     )
     .await


### PR DESCRIPTION
# Description

Increase 4010 rate limit and add JWT validity period leeway.

[Context](https://walletconnect.slack.com/archives/C044SKFKELR/p1705465288509419)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
