### PR TITLE
feat: limit subscription concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=0a21222#0a212225ef63436736af6c6edac1eb65619ad277"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.24.0#d2a772f2a23e6ed8219d2f16af7f88878097388a"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=0a21222#0a212225ef63436736af6c6edac1eb65619ad277"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.24.0#d2a772f2a23e6ed8219d2f16af7f88878097388a"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "ed25519-dalek 2.0.0",
  "envy",
  "futures",
+ "futures-util",
  "hex",
  "hkdf",
  "hyper",
@@ -3117,7 +3118,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.23.4#4d05390a756b766214aa81cbcb5abdc72fb756c4"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=0a21222#0a212225ef63436736af6c6edac1eb65619ad277"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3140,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.23.4#4d05390a756b766214aa81cbcb5abdc72fb756c4"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=0a21222#0a212225ef63436736af6c6edac1eb65619ad277"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,11 @@ data-encoding = "2.3.3"
 chrono = { version = "0.4.23", features = ["serde"] }
 derive_more = "0.99.17"
 futures = "0.3.26"
+futures-util = "0.3"
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.23.4", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.23.4" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "0a21222", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "0a21222" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ futures = "0.3.26"
 futures-util = "0.3"
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "0a21222", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "0a21222" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.24.0", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.24.0" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"


### PR DESCRIPTION
# Description

This limits the relay subscription concurrency to prevent huge database request spikes on reconnections. Also makes use of the new 'blocking' subscriptions. See https://github.com/WalletConnect/WalletConnectRust/pull/56 and https://github.com/WalletConnect/rs-relay/pull/1387.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
