### PR TITLE
fix(ci): using the `current`, `latest` or `manual` image tag in the manual deploy

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -25,7 +25,7 @@ on:
       version:
         description: "Release Version"
         type: string
-        default: '-current-'
+        default: 'latest'
 
 concurrency: deploy
 
@@ -38,7 +38,7 @@ permissions:
 jobs:
   get_deployed_version:
     name: Lookup Version
-    if: ${{ !inputs.deploy-app && inputs.version == '-current-' }}
+    if: ${{ !inputs.deploy-app && inputs.version == 'latest' }}
     secrets: inherit
     uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.1.2
     with:
@@ -54,11 +54,18 @@ jobs:
     runs-on:
       group: ${{ vars.RUN_GROUP }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Select target version
         id: select_version
         run: |
-          if [ "${{ inputs.deploy-app }}" != "true" ] && [ "${{ inputs.version }}" == "-current-" ]; then
+          if [ "${{ inputs.deploy-app }}" != "true" ] && [ "${{ inputs.version }}" == "latest" ]; then
             echo "version=${{ needs.get_deployed_version.outputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.version }}" == "latest" ]; then
+            echo "version=$(git tag | sort --version-sort | tail -n1)" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -1,5 +1,5 @@
 name: ⚙️ Deploy
-run-name: "Deploy: ${{ github.sha }} ➠ ${{ inputs.version }}${{ (!inputs.deploy-infra && !inputs.deploy-app) && ' 👀 deploy nothing' || ''}}${{ inputs.deploy-infra && ' ❱❱  infra' || '' }}${{ inputs.deploy-app && ' ❱❱  app' || '' }}"
+run-name: "Deploy: ${{ github.sha }} ➠ ${{ inputs.version-type }}:${{ inputs.version-tag }}${{ (!inputs.deploy-infra && !inputs.deploy-app) && ' 👀 deploy nothing' || ''}}${{ inputs.deploy-infra && ' ❱❱  infra' || '' }}${{ inputs.deploy-app && ' ❱❱  app' || '' }}"
 
 on:
   workflow_dispatch:
@@ -22,10 +22,19 @@ on:
           - prod
         default: staging
         required: true
-      version:
+      version-type:
         description: "Release Version"
-        type: string
+        type: choice
+        options:
+          - latest
+          - current
+          - manual
         default: 'latest'
+        required: true
+      version-tag:
+        description: "Release Version Tag (for manual version)"
+        type: string
+        default: ''
 
 concurrency: deploy
 
@@ -38,7 +47,7 @@ permissions:
 jobs:
   get_deployed_version:
     name: Lookup Version
-    if: ${{ !inputs.deploy-app && inputs.version == 'latest' }}
+    if: ${{ inputs.version-type == 'current' }}
     secrets: inherit
     uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.1.2
     with:
@@ -62,12 +71,12 @@ jobs:
       - name: Select target version
         id: select_version
         run: |
-          if [ "${{ inputs.deploy-app }}" != "true" ] && [ "${{ inputs.version }}" == "latest" ]; then
+          if [ "${{ inputs.version-type }}" == "current" ]; then
             echo "version=${{ needs.get_deployed_version.outputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ inputs.version }}" == "latest" ]; then
+          elif [ "${{ inputs.version-type }}" == "latest" ]; then
             echo "version=$(git tag | sort --version-sort | tail -n1)" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version-tag }}" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       version: ${{ steps.select_version.outputs.version }}


### PR DESCRIPTION
# Description

This PR fixes the error on the manual dispatch of the [`Deploy` workflow](https://github.com/WalletConnect/notify-server/actions/workflows/dispatch_deploy.yml) with the default `- current -` image tag by making the following changes:
* Making the `Release Version` as an option with the following options:
  * `current` - current deployed image tag.
  * `latest` - latest release tag.
  * `manual` - manual image tag version to deploy.
    * Using the manual tag only when the `manual` option is chosen.

## How Has This Been Tested?

Tested by invoking the workflow from the branch in the same workflow in the `blockchain-api`:
* [Current](https://github.com/WalletConnect/blockchain-api/actions/runs/7609402830)
* [Latest](https://github.com/WalletConnect/blockchain-api/actions/runs/7609486525/job/20720834815#step:1:37)
* [Manual](https://github.com/WalletConnect/blockchain-api/actions/runs/7609526915/job/20720961447#step:1:38)

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
