### PR TITLE
fix: attribute some errors as client errors

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,17 +17,18 @@ check:
   @echo '==> Checking project for compile errors'
   RUST_BACKTRACE=1 cargo check
 
+test := ""
+
 # Run project test suite
 test:
   @echo '==> Testing project (default)'
-  RUST_BACKTRACE=1 cargo test --lib --bins
+  RUST_BACKTRACE=1 cargo test --lib --bins -- {{test}}
 
 # Run project test suite
 test-all:
   @echo '==> Testing project (all features)'
-  RUST_BACKTRACE=1 cargo test --all-features --lib --bins
+  RUST_BACKTRACE=1 cargo test --all-features --lib --bins -- {{test}}
 
-test := ""
 test-integration:
   @echo '==> Testing integration'
   RUST_BACKTRACE=1 ANSI_LOGS=true cargo test --test integration -- {{test}}

--- a/src/config/deployed/mod.rs
+++ b/src/config/deployed/mod.rs
@@ -1,6 +1,6 @@
 use {
     super::Configuration,
-    crate::error::Result,
+    crate::error::NotifyServerError,
     relay_rpc::domain::ProjectId,
     serde::Deserialize,
     std::net::{IpAddr, Ipv4Addr},
@@ -75,7 +75,7 @@ fn default_redis_pool_size() -> u32 {
     64
 }
 
-pub fn get_configuration() -> Result<Configuration> {
+pub fn get_configuration() -> Result<Configuration, NotifyServerError> {
     let config = envy::from_env::<DeployedConfiguration>()?;
 
     Ok(Configuration {

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -1,6 +1,6 @@
 use {
     super::Configuration,
-    crate::error::Result,
+    crate::error::NotifyServerError,
     dotenvy::dotenv,
     relay_rpc::domain::ProjectId,
     serde::Deserialize,
@@ -71,7 +71,7 @@ fn default_registry_url() -> Url {
     "https://registry.walletconnect.com".parse().unwrap()
 }
 
-pub fn get_configuration() -> Result<Configuration> {
+pub fn get_configuration() -> Result<Configuration, NotifyServerError> {
     load_dot_env()?;
     let config = envy::from_env::<LocalConfiguration>()?;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,7 @@
 use {
-    crate::{error::Result, rate_limit::Clock, registry::storage::redis::Addr as RedisAddr},
+    crate::{
+        error::NotifyServerError, rate_limit::Clock, registry::storage::redis::Addr as RedisAddr,
+    },
     relay_rpc::domain::ProjectId,
     std::{env, net::IpAddr},
     url::Url,
@@ -57,7 +59,7 @@ impl Configuration {
     }
 }
 
-pub fn get_configuration() -> Result<Configuration> {
+pub fn get_configuration() -> Result<Configuration, NotifyServerError> {
     if env::var("ENVIRONMENT") == Ok("DEPLOYED".to_owned()) {
         deployed::get_configuration()
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use {
-    notify_server::{bootstrap, config::get_configuration, error::Result},
+    notify_server::{bootstrap, config::get_configuration, error::NotifyServerError},
     tokio::sync::broadcast,
     tracing_subscriber::fmt::format::FmtSpan,
 };
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), NotifyServerError> {
     let config = get_configuration()?;
 
     tracing_subscriber::fmt()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -336,6 +336,7 @@ pub async fn http_request_middleware<B>(
 
 pub enum RelayIncomingMessageStatus {
     Success,
+    ClientError,
     ServerError,
 }
 
@@ -343,6 +344,7 @@ impl Display for RelayIncomingMessageStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Success => write!(f, "success"),
+            Self::ClientError => write!(f, "client_error"),
             Self::ServerError => write!(f, "server_error"),
         }
     }

--- a/src/model/types/mod.rs
+++ b/src/model/types/mod.rs
@@ -1,5 +1,7 @@
 use {
-    crate::{services::websocket_server::decode_key, utils::get_client_id},
+    crate::{
+        error::NotifyServerError, services::websocket_server::decode_key, utils::get_client_id,
+    },
     chrono::{DateTime, Utc},
     relay_rpc::domain::{DecodedClientId, ProjectId, Topic},
     sqlx::FromRow,
@@ -26,7 +28,7 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn get_authentication_client_id(&self) -> crate::error::Result<DecodedClientId> {
+    pub fn get_authentication_client_id(&self) -> Result<DecodedClientId, NotifyServerError> {
         Ok(get_client_id(&ed25519_dalek::VerifyingKey::from_bytes(
             &decode_key(&self.authentication_public_key)?,
         )?))

--- a/src/notify_keys.rs
+++ b/src/notify_keys.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        error::{Error, Result},
+        error::NotifyServerError,
         utils::{get_client_id, topic_from_key},
     },
     rand_chacha::{
@@ -22,10 +22,10 @@ pub struct NotifyKeys {
 }
 
 impl NotifyKeys {
-    pub fn new(notify_url: &Url, keypair_seed: [u8; 32]) -> Result<Self> {
+    pub fn new(notify_url: &Url, keypair_seed: [u8; 32]) -> Result<Self, NotifyServerError> {
         let domain = notify_url
             .host_str()
-            .ok_or(Error::UrlMissingHost)?
+            .ok_or(NotifyServerError::UrlMissingHost)?
             .to_owned();
 
         // Use specific RNG instead of StdRng because StdRng can change implementations

--- a/src/notify_message.rs
+++ b/src/notify_message.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         auth::{add_ttl, sign_jwt},
-        error::Result,
+        error::NotifyServerError,
         model::types::AccountId,
         spec::{NOTIFY_MESSAGE_ACT, NOTIFY_MESSAGE_TTL},
     },
@@ -28,7 +28,7 @@ pub fn sign_message(
         private_key,
         app,
     }: &ProjectSigningDetails,
-) -> Result<String> {
+) -> Result<String, NotifyServerError> {
     let now = Utc::now();
     let message = NotifyMessage {
         iat: now.timestamp(),

--- a/src/rate_limit/token_bucket.rs
+++ b/src/rate_limit/token_bucket.rs
@@ -1,11 +1,15 @@
 use {
     crate::{
-        error::{Error, Result},
+        error::NotifyServerError,
         registry::storage::redis::Redis,
+        services::websocket_server::error::{
+            RelayMessageClientError, RelayMessageError, RelayMessageServerError,
+        },
     },
     chrono::{DateTime, Duration, Utc},
     core::fmt,
-    redis::Script,
+    deadpool_redis::PoolError,
+    redis::{RedisError, Script},
     std::{collections::HashMap, sync::Arc},
 };
 
@@ -15,6 +19,43 @@ pub trait ClockImpl: fmt::Debug + Send + Sync {
 
 pub type Clock = Option<Arc<dyn ClockImpl>>;
 
+#[derive(Debug, thiserror::Error)]
+#[error("Rate limit exceeded. Try again at {reset}")]
+pub struct RateLimitExceeded {
+    reset: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RateLimitError {
+    #[error(transparent)]
+    RateLimitExceeded(RateLimitExceeded),
+
+    #[error("Internal error: {0}")]
+    InternalError(InternalRateLimitError),
+}
+
+impl From<RateLimitError> for NotifyServerError {
+    fn from(error: RateLimitError) -> Self {
+        match error {
+            RateLimitError::RateLimitExceeded(e) => Self::TooManyRequests(e),
+            RateLimitError::InternalError(e) => Self::RateLimitError(e),
+        }
+    }
+}
+
+impl From<RateLimitError> for RelayMessageError {
+    fn from(error: RateLimitError) -> Self {
+        match error {
+            RateLimitError::RateLimitExceeded(e) => {
+                RelayMessageClientError::RateLimitExceeded(e).into()
+            }
+            RateLimitError::InternalError(e) => {
+                RelayMessageServerError::NotifyServerError(e.into()).into()
+            }
+        }
+    }
+}
+
 pub async fn token_bucket(
     redis: &Arc<Redis>,
     key: String,
@@ -22,7 +63,7 @@ pub async fn token_bucket(
     interval: Duration,
     refill_rate: u32,
     clock: &Clock,
-) -> Result<()> {
+) -> Result<(), RateLimitError> {
     let result = token_bucket_many(
         redis,
         vec![key.clone()],
@@ -31,13 +72,25 @@ pub async fn token_bucket(
         refill_rate,
         clock,
     )
-    .await?;
-    let (remaining, reset) = result.get(&key).unwrap();
+    .await
+    .map_err(RateLimitError::InternalError)?;
+    let (remaining, reset) = result.get(&key).expect("Should contain the key");
     if remaining.is_negative() {
-        Err(Error::TooManyRequests(reset / 1000))
+        Err(RateLimitError::RateLimitExceeded(RateLimitExceeded {
+            reset: reset / 1000,
+        }))
     } else {
         Ok(())
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InternalRateLimitError {
+    #[error("Pool error {0}")]
+    PoolError(PoolError),
+
+    #[error("Redis error: {0}")]
+    RedisError(RedisError),
 }
 
 pub async fn token_bucket_many(
@@ -47,7 +100,7 @@ pub async fn token_bucket_many(
     interval: Duration,
     refill_rate: u32,
     clock: &Clock,
-) -> Result<HashMap<String, (i64, u64)>> {
+) -> Result<HashMap<String, (i64, u64)>, InternalRateLimitError> {
     let now = clock.as_ref().map_or_else(Utc::now, |clock| clock.now());
 
     // Remaining is number of tokens remaining. -1 for rate limited.
@@ -58,8 +111,14 @@ pub async fn token_bucket_many(
         .arg(interval.num_milliseconds())
         .arg(refill_rate)
         .arg(now.timestamp_millis())
-        .invoke_async::<_, String>(&mut redis.write_pool().get().await?)
+        .invoke_async::<_, String>(
+            &mut redis
+                .write_pool()
+                .get()
+                .await
+                .map_err(InternalRateLimitError::PoolError)?,
+        )
         .await
-        .map_err(Into::into)
+        .map_err(InternalRateLimitError::RedisError)
         .map(|value| serde_json::from_str(&value).expect("Redis script should return valid JSON"))
 }

--- a/src/relay_client_helpers.rs
+++ b/src/relay_client_helpers.rs
@@ -1,5 +1,5 @@
 use {
-    crate::error::{Error, Result},
+    crate::error::NotifyServerError,
     relay_client::{http::Client, ConnectionOptions},
     relay_rpc::{
         auth::{ed25519_dalek::Keypair, AuthToken},
@@ -15,7 +15,7 @@ pub fn create_http_client(
     relay_url: Url,
     notify_url: Url,
     project_id: ProjectId,
-) -> Result<Client> {
+) -> Result<Client, NotifyServerError> {
     Ok(Client::new(&create_http_connect_options(
         keypair, relay_url, notify_url, project_id,
     )?)?)
@@ -26,10 +26,10 @@ pub fn create_http_connect_options(
     mut relay_url: Url,
     notify_url: Url,
     project_id: ProjectId,
-) -> Result<ConnectionOptions> {
+) -> Result<ConnectionOptions, NotifyServerError> {
     relay_url
         .set_scheme(&relay_url.scheme().replace("ws", "http"))
-        .map_err(|_| Error::UrlSetScheme)?;
+        .map_err(|_| NotifyServerError::UrlSetScheme)?;
 
     let rpc_address = relay_url.join("/rpc")?;
     Ok(
@@ -44,7 +44,7 @@ pub fn create_ws_connect_options(
     relay_url: Url,
     notify_url: Url,
     project_id: ProjectId,
-) -> Result<ConnectionOptions> {
+) -> Result<ConnectionOptions, NotifyServerError> {
     Ok(create_connect_options(
         keypair,
         &relay_url,
@@ -61,7 +61,7 @@ fn create_connect_options(
     notify_url: Url,
     project_id: ProjectId,
     ttl: Option<Duration>,
-) -> Result<ConnectionOptions> {
+) -> Result<ConnectionOptions, NotifyServerError> {
     let auth = AuthToken::new(notify_url.clone())
         .aud(relay_url.origin().ascii_serialization())
         .ttl(ttl)

--- a/src/services/public_http_server/handlers/did_json.rs
+++ b/src/services/public_http_server/handlers/did_json.rs
@@ -1,6 +1,11 @@
 use {
-    crate::{auth::DidWeb, error::Result, notify_keys::NotifyKeys, state::AppState},
-    axum::{extract::State, http::StatusCode, response::IntoResponse, Json},
+    crate::{auth::DidWeb, error::NotifyServerError, notify_keys::NotifyKeys, state::AppState},
+    axum::{
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        Json,
+    },
     data_encoding::BASE64URL,
     serde::{Deserialize, Serialize},
     std::sync::Arc,
@@ -10,7 +15,7 @@ use {
 // No rate limit necessary since returning a fixed string is less computational intensive than tracking the rate limit
 
 // TODO generate this response at app startup to avoid unnecessary string allocations
-pub async fn handler(State(state): State<Arc<AppState>>) -> Result<axum::response::Response> {
+pub async fn handler(State(state): State<Arc<AppState>>) -> Result<Response, NotifyServerError> {
     info!("Serving did.json");
 
     let json = generate_json(&state.notify_keys);

--- a/src/services/public_http_server/handlers/get_subscribers_v0.rs
+++ b/src/services/public_http_server/handlers/get_subscribers_v0.rs
@@ -1,11 +1,14 @@
 use {
     crate::{
-        error::{Error, Result},
-        model::helpers::get_subscriber_accounts_by_project_id,
-        registry::extractor::AuthedProjectId,
-        state::AppState,
+        error::NotifyServerError, model::helpers::get_subscriber_accounts_by_project_id,
+        registry::extractor::AuthedProjectId, state::AppState,
     },
-    axum::{extract::State, http::StatusCode, response::IntoResponse, Json},
+    axum::{
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        Json,
+    },
     std::sync::Arc,
     tracing::instrument,
 };
@@ -14,12 +17,14 @@ use {
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     AuthedProjectId(project_id, _): AuthedProjectId,
-) -> Result<axum::response::Response> {
+) -> Result<Response, NotifyServerError> {
     let accounts =
         get_subscriber_accounts_by_project_id(project_id, &state.postgres, state.metrics.as_ref())
             .await
             .map_err(|e| match e {
-                sqlx::Error::RowNotFound => Error::BadRequest("Project not found".into()),
+                sqlx::Error::RowNotFound => {
+                    NotifyServerError::BadRequest("Project not found".into())
+                }
                 e => e.into(),
             })?;
 

--- a/src/services/public_http_server/handlers/get_subscribers_v1.rs
+++ b/src/services/public_http_server/handlers/get_subscribers_v1.rs
@@ -1,12 +1,17 @@
 use {
     crate::{
-        error::{Error, Result},
+        error::NotifyServerError,
         model::helpers::get_subscriber_accounts_and_scopes_by_project_id,
-        rate_limit::{self, Clock},
+        rate_limit::{self, Clock, RateLimitError},
         registry::{extractor::AuthedProjectId, storage::redis::Redis},
         state::AppState,
     },
-    axum::{extract::State, http::StatusCode, response::IntoResponse, Json},
+    axum::{
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        Json,
+    },
     relay_rpc::domain::ProjectId,
     std::sync::Arc,
     tracing::instrument,
@@ -16,7 +21,7 @@ use {
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     AuthedProjectId(project_id, _): AuthedProjectId,
-) -> Result<axum::response::Response> {
+) -> Result<Response, NotifyServerError> {
     if let Some(redis) = state.redis.as_ref() {
         get_subscribers_rate_limit(redis, &project_id, &state.clock).await?;
     }
@@ -28,7 +33,7 @@ pub async fn handler(
     )
     .await
     .map_err(|e| match e {
-        sqlx::Error::RowNotFound => Error::BadRequest("Project not found".into()),
+        sqlx::Error::RowNotFound => NotifyServerError::BadRequest("Project not found".into()),
         e => e.into(),
     })?;
 
@@ -39,7 +44,7 @@ pub async fn get_subscribers_rate_limit(
     redis: &Arc<Redis>,
     project_id: &ProjectId,
     clock: &Clock,
-) -> Result<()> {
+) -> Result<(), RateLimitError> {
     rate_limit::token_bucket(
         redis,
         project_id.to_string(),

--- a/src/services/websocket_server/error.rs
+++ b/src/services/websocket_server/error.rs
@@ -1,0 +1,37 @@
+use {
+    crate::{error::NotifyServerError, rate_limit::RateLimitExceeded, types::EnvelopeParseError},
+    relay_rpc::domain::Topic,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RelayMessageClientError {
+    #[error("Received wc_notifyWatchSubscriptions (4010) on wrong topic: {0}")]
+    WrongNotifyWatchSubscriptionsTopic(Topic),
+
+    #[error("Decode message: {0}")]
+    DecodeMessage(#[from] base64::DecodeError),
+
+    #[error("Could not parse message envelope: {0}")]
+    EnvelopeParseError(#[from] EnvelopeParseError),
+
+    #[error(transparent)]
+    RateLimitExceeded(RateLimitExceeded),
+
+    #[error("Not authorized to control that app's subscriptions")]
+    AppSubscriptionsUnauthorized,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RelayMessageServerError {
+    #[error(transparent)]
+    NotifyServerError(#[from] NotifyServerError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RelayMessageError {
+    #[error("Relay message client error: {0}")]
+    Client(#[from] RelayMessageClientError),
+
+    #[error("Relay message server error: {0}")]
+    Server(#[from] RelayMessageServerError),
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         analytics::NotifyAnalytics,
-        error::Result,
+        error::NotifyServerError,
         metrics::Metrics,
         notify_keys::NotifyKeys,
         rate_limit::Clock,
@@ -47,7 +47,7 @@ impl AppState {
         redis: Option<Arc<Redis>>,
         registry: Arc<Registry>,
         clock: Clock,
-    ) -> crate::Result<Self> {
+    ) -> Result<Self, NotifyServerError> {
         let build_info: &BuildInfo = build_info();
 
         let notify_keys = NotifyKeys::new(&config.notify_url, keypair_seed)?;
@@ -73,10 +73,10 @@ impl AppState {
         project_id: &str,
         event: WebhookNotificationEvent,
         account: &str,
-    ) -> Result<()> {
+    ) -> Result<(), NotifyServerError> {
         if !is_valid_account(account) {
             info!("Didn't register account - invalid account: {account} for project {project_id}");
-            return Err(crate::error::Error::InvalidAccount);
+            return Err(NotifyServerError::InvalidAccount);
         }
 
         info!(

--- a/src/types/notification.rs
+++ b/src/types/notification.rs
@@ -1,5 +1,5 @@
 use {
-    crate::error::{Error, Result},
+    crate::error::NotifyServerError,
     serde::{Deserialize, Serialize},
     uuid::Uuid,
     validator::Validate,
@@ -19,8 +19,8 @@ pub struct Notification {
 }
 
 impl Notification {
-    pub fn validate(&self) -> Result<()> {
-        Validate::validate(&self).map_err(|error| Error::BadRequest(error.to_string()))
+    pub fn validate(&self) -> Result<(), NotifyServerError> {
+        Validate::validate(&self).map_err(|error| NotifyServerError::BadRequest(error.to_string()))
     }
 }
 

--- a/tests/deployment.rs
+++ b/tests/deployment.rs
@@ -986,7 +986,7 @@ async fn run_test(statement: String, watch_subscriptions_all_domains: bool) {
         .unwrap();
 
     let resp = resp
-        .json::<notify_server::services::public_http_server::handlers::notify_v0::Response>()
+        .json::<notify_server::services::public_http_server::handlers::notify_v0::ResponseBody>()
         .await
         .unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1377,7 +1377,7 @@ async fn test_notify_v1(notify_server: &NotifyServerContext) {
             .unwrap(),
     )
     .await
-    .json::<notify_v1::Response>()
+    .json::<notify_v1::ResponseBody>()
     .await
     .unwrap();
     assert!(response.not_found.is_empty());
@@ -1454,7 +1454,7 @@ async fn test_notify_v1_response_not_found(notify_server: &NotifyServerContext) 
             .unwrap(),
     )
     .await
-    .json::<notify_v1::Response>()
+    .json::<notify_v1::ResponseBody>()
     .await
     .unwrap();
     assert_eq!(response.not_found, HashSet::from([account.clone()]));
@@ -1532,7 +1532,7 @@ async fn test_notify_v1_response_not_subscribed_to_scope(notify_server: &NotifyS
             .unwrap(),
     )
     .await
-    .json::<notify_v1::Response>()
+    .json::<notify_v1::ResponseBody>()
     .await
     .unwrap();
     assert!(response.not_found.is_empty());
@@ -1881,7 +1881,7 @@ async fn test_notify_subscriber_rate_limit(notify_server: &NotifyServerContext) 
 
     let response = assert_successful_response(notify().await)
         .await
-        .json::<notify_v1::Response>()
+        .json::<notify_v1::ResponseBody>()
         .await
         .unwrap();
     assert!(response.not_found.is_empty());
@@ -1890,7 +1890,7 @@ async fn test_notify_subscriber_rate_limit(notify_server: &NotifyServerContext) 
 
     let response = assert_successful_response(notify().await)
         .await
-        .json::<notify_v1::Response>()
+        .json::<notify_v1::ResponseBody>()
         .await
         .unwrap();
     assert!(response.not_found.is_empty());
@@ -2011,7 +2011,7 @@ async fn test_notify_subscriber_rate_limit_single(notify_server: &NotifyServerCo
 
     let response = assert_successful_response(notify().await)
         .await
-        .json::<notify_v1::Response>()
+        .json::<notify_v1::ResponseBody>()
         .await
         .unwrap();
     assert!(response.not_found.is_empty());
@@ -2023,7 +2023,7 @@ async fn test_notify_subscriber_rate_limit_single(notify_server: &NotifyServerCo
 
     let response = assert_successful_response(notify().await)
         .await
-        .json::<notify_v1::Response>()
+        .json::<notify_v1::ResponseBody>()
         .await
         .unwrap();
     assert!(response.not_found.is_empty());
@@ -4095,7 +4095,7 @@ async fn delete_subscription(notify_server: &NotifyServerContext) {
             .unwrap(),
     )
     .await
-    .json::<notify_server::services::public_http_server::handlers::notify_v0::Response>()
+    .json::<notify_server::services::public_http_server::handlers::notify_v0::ResponseBody>()
     .await
     .unwrap();
 
@@ -6545,7 +6545,7 @@ async fn delete_and_resubscribe(notify_server: &NotifyServerContext) {
             .unwrap(),
     )
     .await
-    .json::<notify_server::services::public_http_server::handlers::notify_v0::Response>()
+    .json::<notify_server::services::public_http_server::handlers::notify_v0::ResponseBody>()
     .await
     .unwrap();
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -4,6 +4,7 @@ use {
     k256::ecdsa::SigningKey,
     notify_server::{
         auth::{AuthError, GetSharedClaims, SharedClaims},
+        error::NotifyServerError,
         model::types::AccountId,
         notify_message::NotifyMessage,
         relay_client_helpers::create_ws_connect_options,
@@ -59,7 +60,7 @@ pub async fn create_client(
 
 // Workaround https://github.com/rust-lang/rust-clippy/issues/11613
 #[allow(clippy::needless_return_with_question_mark)]
-pub fn verify_jwt(jwt: &str, key: &VerifyingKey) -> notify_server::error::Result<NotifyMessage> {
+pub fn verify_jwt(jwt: &str, key: &VerifyingKey) -> Result<NotifyMessage, NotifyServerError> {
     // Refactor to call from_jwt() and then check `iss` with:
     // let pub_key = did_key.parse::<DecodedClientId>()?;
     // let key = jsonwebtoken::DecodingKey::from_ed_der(pub_key.as_ref());


### PR DESCRIPTION
# Description

Working towards: https://github.com/WalletConnect/notify-server/issues/285

We change the return type of the relay message handler functions from NotifyServerError to RelayMessageError, and distinguish between these two. For now, server errors continue to be represented as NotifyServerError but this will be refactored in future PRs.

This PR also introduces some TODOs and some more error variants in the top-level NotifyServerError, but these will be eliminated in future PRs as errors are refactored into more complex types.

This PR also renames Error to NotifyServerError and removes the generic Result type as we should be using more specific error return types, rather than 1 error type for everything.

Also fixes that short message lengths could cause panics instead of being handled gracefully.

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
