### PR TITLE
fix: chain agnostic notify response

### DIFF
--- a/src/services/public_http_server/handlers/notify_v1.rs
+++ b/src/services/public_http_server/handlers/notify_v1.rs
@@ -3,7 +3,9 @@ use {
         error::NotifyServerError,
         metrics::Metrics,
         model::{
-            helpers::{get_project_by_project_id, get_subscribers_for_project_in},
+            helpers::{
+                get_project_by_project_id, get_subscribers_for_project_in, NotifySubscriberInfo,
+            },
             types::AccountId,
         },
         rate_limit::{self, Clock, InternalRateLimitError, RateLimitError},
@@ -13,6 +15,7 @@ use {
         },
         state::AppState,
         types::Notification,
+        utils::get_address_from_account,
     },
     axum::{
         extract::State,
@@ -130,13 +133,33 @@ pub async fn handler_impl(
         // We assume all accounts were not found until found
         response.not_found.extend(accounts.iter().cloned());
 
-        let subscribers = get_subscribers_for_project_in(
-            project.id,
-            &accounts,
-            &state.postgres,
-            state.metrics.as_ref(),
-        )
-        .await?;
+        let subscribers = {
+            let chain_agnostic_lookup_table = accounts
+                .iter()
+                .map(|account| {
+                    (
+                        get_address_from_account(account).to_owned(),
+                        account.clone(),
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            get_subscribers_for_project_in(
+                project.id,
+                &accounts,
+                &state.postgres,
+                state.metrics.as_ref(),
+            )
+            .await?
+            .into_iter()
+            .map(|subscriber| NotifySubscriberInfo {
+                account: chain_agnostic_lookup_table
+                    .get(get_address_from_account(&subscriber.account))
+                    .unwrap()
+                    .clone(),
+                ..subscriber
+            })
+            .collect::<Vec<_>>()
+        };
 
         let mut valid_subscribers = Vec::with_capacity(subscribers.len());
         for subscriber in subscribers {


### PR DESCRIPTION
# Description

Fix that `/notify` endpoint returned the original account IDs rather than the ones uses in the request.

## How Has This Been Tested?

New tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
