### PR TITLE
fix: CC0-1.0 not found

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,6 @@ copyleft = "deny"
 allow = [
     "Apache-2.0",
     "MIT",
-    "CC0-1.0",
     "Unlicense",
     "BSD-3-Clause",
     "0BSD",


### PR DESCRIPTION
# Description

Fixes CI failure from updated cargo-check version. E.g. https://github.com/WalletConnect/notify-server/actions/runs/7595391279/job/20687904506?pr=299

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
