### PR TITLE
fix: show separate metrics per replica

### DIFF
--- a/terraform/monitoring/panels/app/publishing_workers_count.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_count.libsonnet
@@ -12,9 +12,8 @@ local targets   = grafana.targets;
     )
     .configure(defaults.configuration.timeseries)
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr          = 'publishing_workers_count',
-      legendFormat  = 'Running workers',
-      refId         = "pub_workers_count",
+      datasource   = ds.prometheus,
+      expr         = 'publishing_workers_count',
+      legendFormat = 'r{{aws_ecs_task_revision}}',
     ))
 }

--- a/terraform/monitoring/panels/app/publishing_workers_errors.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_errors.libsonnet
@@ -12,8 +12,8 @@ local targets   = grafana.targets;
     )
     .configure(defaults.configuration.timeseries)
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(publishing_workers_errors_total{}[$__rate_interval]))',
-      refId       = "availability",
+      datasource   = ds.prometheus,
+      expr         = 'rate(publishing_workers_errors_total{}[$__rate_interval])',
+      legendFormat = 'r{{aws_ecs_task_revision}}',
     ))
 }

--- a/terraform/monitoring/panels/app/publishing_workers_processing_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_processing_size.libsonnet
@@ -12,8 +12,8 @@ local targets   = grafana.targets;
     )
     .configure(defaults.configuration.timeseries)
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(publishing_queue_processing_size{})',
-      refId       = "pub_processing_size",
+      datasource   = ds.prometheus,
+      expr         = 'publishing_queue_processing_size',
+      legendFormat = "r{{aws_ecs_task_revision}}"
     ))
 }

--- a/terraform/monitoring/panels/app/publishing_workers_published_count.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_published_count.libsonnet
@@ -12,8 +12,8 @@ local targets   = grafana.targets;
     )
     .configure(defaults.configuration.timeseries)
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(publishing_queue_published_count_total{}[$__rate_interval]))',
-      refId       = "pub_published_count",
+      datasource   = ds.prometheus,
+      expr         = 'rate(publishing_queue_published_count_total{}[$__rate_interval])',
+      legendFormat = "r{{aws_ecs_task_revision}}"
     ))
 }

--- a/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
@@ -12,8 +12,9 @@ local targets   = grafana.targets;
     )
     .configure(defaults.configuration.timeseries)
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(publishing_queue_queued_size{})',
-      refId       = "pub_msgs_queue_size",
+      datasource   = ds.prometheus,
+      expr         = 'publishing_queue_queued_size',
+      refId        = "pub_msgs_queue_size",
+      legendFormat = "r{{aws_ecs_task_revision}}"
     ))
 }

--- a/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
@@ -14,7 +14,6 @@ local targets   = grafana.targets;
     .addTarget(targets.prometheus(
       datasource   = ds.prometheus,
       expr         = 'publishing_queue_queued_size',
-      refId        = "pub_msgs_queue_size",
       legendFormat = "r{{aws_ecs_task_revision}}"
     ))
 }


### PR DESCRIPTION
# Description

The counts double during a deployment because of `sum`. Standardize on showing separate graphs for all metrics.

Also update legend format to show revision # like the other charts, and remove unused refIds.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
