### PR TITLE
fix: don't alarm on get subscribers endpoint

### DIFF
--- a/terraform/monitoring/panels/app/http_request_latency.libsonnet
+++ b/terraform/monitoring/panels/app/http_request_latency.libsonnet
@@ -23,10 +23,10 @@ local targets   = grafana.targets;
       noDataState   = 'no_data',
       conditions    = [
         grafana.alertCondition.new(
-          evaluatorParams = [ 3000 ],
+          evaluatorParams = [ 2000 ],
           evaluatorType   = 'gt',
           operatorType    = 'or',
-          queryRefId      = 'HttpRequestLatency',
+          queryRefId      = 'FilteredHttpRequestLatency',
           queryTimeStart  = '5m',
           queryTimeEnd    = 'now',
           reducerType     = grafana.alert_reducers.Avg
@@ -40,5 +40,14 @@ local targets   = grafana.targets;
       legendFormat  = '{{method}} {{endpoint}} r{{aws_ecs_task_revision}}',
       exemplar      = false,
       refId         = 'HttpRequestLatency',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by (aws_ecs_task_revision, method, endpoint) (rate(http_request_latency_sum{endpoint!="/:project_id/subscribers"}[$__rate_interval])) / sum by (aws_ecs_task_revision, method, endpoint) (rate(http_request_latency_count{endpoint!="/:project_id/subscribers"}[$__rate_interval]))',
+      legendFormat  = '{{method}} {{endpoint}} r{{aws_ecs_task_revision}}',
+      exemplar      = false,
+      refId         = 'FilteredHttpRequestLatency',
+      hide          = true,
     ))
 }


### PR DESCRIPTION
# Description

`GET /subscribers` endpoint is known slow due to inefficiency of downloading all subscribers and is causing [alarms](https://walletconnect.slack.com/archives/C058RS0MH38/p1705848849714019).

This PR disables the alarm for this endpoint as it will always be slow. Some other improvements must be made though to have performance overall: https://github.com/WalletConnect/notify-server/issues/309

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
