### PR TITLE
fix: 4x subscribe request concurrency

### DIFF
--- a/src/services/websocket_server/mod.rs
+++ b/src/services/websocket_server/mod.rs
@@ -180,7 +180,7 @@ async fn resubscribe(
         .collect::<Vec<_>>();
 
     // Limit concurrency to avoid overwhelming the relay with requests.
-    const REQUEST_CONCURRENCY: usize = 48;
+    const REQUEST_CONCURRENCY: usize = 200;
 
     futures_util::stream::iter(topics)
         .map(|topics| {


### PR DESCRIPTION
# Description

Reduce time it takes to subscribe to relay topics

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
