### PR TITLE
fix: alarm when count in last 5 minutes less than 1 not rate less than 1/s

### DIFF
--- a/terraform/monitoring/panels/app/relay_incoming_message_rate.libsonnet
+++ b/terraform/monitoring/panels/app/relay_incoming_message_rate.libsonnet
@@ -45,7 +45,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = 'sum(rate(relay_incoming_messages_total{tag="4010"}[$__rate_interval]))',
+      expr          = 'increase(relay_incoming_messages_total{tag="4010"}[$__rate_interval])',
       legendFormat  = '{{tag}} r{{aws_ecs_task_revision}}',
       exemplar      = true,
       refId         = 'RelayIncomingWatchSubscriptionsRate',


### PR DESCRIPTION
# Description

This was alarming when rate went below 1/s but we want to see when the count goes to <1 not the rate <1

## How Has This Been Tested?

Manually in Grafana

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
