### PR TITLE
fix: assert correct response counts

### DIFF
--- a/src/services/public_http_server/handlers/notify_v1.rs
+++ b/src/services/public_http_server/handlers/notify_v1.rs
@@ -30,7 +30,7 @@ use {
         sync::Arc,
         time::Instant,
     },
-    tracing::{info, instrument},
+    tracing::{error, info, instrument},
     uuid::Uuid,
     wc::metrics::otel::{Context, KeyValue},
 };
@@ -220,6 +220,11 @@ pub async fn handler_impl(
             state.metrics.as_ref(),
         )
         .await?;
+
+        if accounts.len() != response.sent.len() + response.not_found.len() + response.failed.len()
+        {
+            error!("Notify: Status response count does not match request count. Project: {project_id}, accounts: {accounts:?}, response: {response:?}");
+        }
     }
 
     info!("Response: {response:?} for /v1/notify from project: {project_id}");


### PR DESCRIPTION
# Description

Make sure we are sending back the right results. There should be exactly 1 status for each input account. Will manually check logs for this error.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
