### PR TITLE
fix: panic when calling /notify with invalid AccountId

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -201,7 +201,7 @@ pub fn generate_eoa() -> (SigningKey, String) {
 }
 
 pub fn format_eip155_account(chain_id: u32, address: &str) -> AccountId {
-    format!("eip155:{chain_id}:{address}").into()
+    AccountId::try_from(format!("eip155:{chain_id}:{address}")).unwrap()
 }
 
 pub fn generate_account() -> (SigningKey, AccountId) {


### PR DESCRIPTION
# Description

Calling `/notify` with an invalid AccountId (e.g. just an address w/o chain prefix) will trigger a panic at https://github.com/WalletConnect/notify-server/blob/85edd887622ad0a1e7a9a96e7a73794202e3d323/src/utils.rs#L23

This is because the AccountId is not validated in request payloads.

Update the logic to enforce this at the AccountId construction level. Switch from `new_type!` macro which bypasses try_from and implement custom serde deserializer.

## How Has This Been Tested?

New test case.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
