### PR TITLE
fix: 4010 alarm

### DIFF
--- a/terraform/monitoring/panels/app/relay_incoming_message_rate.libsonnet
+++ b/terraform/monitoring/panels/app/relay_incoming_message_rate.libsonnet
@@ -45,7 +45,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = 'increase(relay_incoming_messages_total{tag="4010"}[$__rate_interval])',
+      expr          = 'sum(increase(relay_incoming_messages_total{tag="4010"}[$__rate_interval]))',
       legendFormat  = '{{tag}} r{{aws_ecs_task_revision}}',
       exemplar      = true,
       refId         = 'RelayIncomingWatchSubscriptionsRate',


### PR DESCRIPTION
# Description

Alarm was firing because there were other lines without the data. Add `sum` so any line/metric will count as traffic.

## How Has This Been Tested?

Manually in Grafana

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
