### PR TITLE
fix(ci): reducing fetch depth to omit old tags

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 15
           fetch-tags: true
       - name: Select target version
         id: select_version


### PR DESCRIPTION
# Description

This PR reduces the fetch depth for looking at the latest tags to omit the old formatted `v` suffixed tags.
The depth size `15` should be enough to omit the old tags and to get the commit in the list with the latest tag.

## How Has This Been Tested?

Run this action from this branch: [Successfully got the latest version tag](https://github.com/WalletConnect/notify-server/actions/runs/7623522352/job/20763733615#step:1:38).

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
