### PR TITLE
fix: notify server not subscribed

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -25,7 +25,6 @@ use {
 pub struct ProjectWithPublicKeys {
     pub authentication_public_key: String,
     pub subscribe_public_key: String,
-    pub topic: String,
 }
 
 pub async fn upsert_project(
@@ -83,7 +82,7 @@ async fn upsert_project_impl(
         ON CONFLICT (project_id) DO UPDATE SET
             updated_at=now(),
             app_domain=$2
-        RETURNING authentication_public_key, subscribe_public_key, topic
+        RETURNING authentication_public_key, subscribe_public_key
     ";
     let start = Instant::now();
     let result = sqlx::query_as::<Postgres, ProjectWithPublicKeys>(query)

--- a/src/services/public_http_server/handlers/subscribe_topic.rs
+++ b/src/services/public_http_server/handlers/subscribe_topic.rs
@@ -99,11 +99,8 @@ pub async fn handler(
         other => other.into(),
     })?;
 
-    // Don't call subscribe if we are already subscribed in a previous request
-    if project.topic == topic.as_ref() {
-        info!("Subscribing to project topic: {topic}");
-        subscribe_relay_topic(&state.relay_ws_client, &topic, state.metrics.as_ref()).await?;
-    }
+    info!("Subscribing to project topic: {topic}");
+    subscribe_relay_topic(&state.relay_ws_client, &topic, state.metrics.as_ref()).await?;
 
     Ok(Json(SubscribeTopicResponseBody {
         authentication_key: project.authentication_public_key,


### PR DESCRIPTION
# Description

Reverts #230 

This was flawed for several reasons:
- The subscribe could fail to complete in the relay because we are not yet using blocking subscriptions
- The subscription expires after 5 minutes without any messages
- ~~The subscription expires after 30 days (no resubscribes for this anywhere!!)~~ Edit: we subscribe upon reconnection to the relay, but this does assume a reconnect takes place at least once every 30 days.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
