### PR TITLE
fix: only show metrics for the deployed database

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -23,6 +23,7 @@ local vars  = {
 
   ecs_service_name: std.extVar('ecs_service_name'),
   ecs_cluster_name: std.extVar('ecs_cluster_name'),
+  rds_cluster_id:   std.extVar('rds_cluster_id'),
   redis_cluster_id: std.extVar('redis_cluster_id'),
   load_balancer:    std.extVar('load_balancer'),
   target_group:     std.extVar('target_group'),

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -13,6 +13,7 @@ data "jsonnet_file" "dashboard" {
 
     ecs_cluster_name = var.ecs_cluster_name
     ecs_service_name = var.ecs_service_name
+    rds_cluster_id   = var.rds_cluster_id
     redis_cluster_id = var.redis_cluster_id
     load_balancer    = var.load_balancer_arn
     target_group     = var.ecs_target_group_arn

--- a/terraform/monitoring/panels/rds/cpu.libsonnet
+++ b/terraform/monitoring/panels/rds/cpu.libsonnet
@@ -28,6 +28,10 @@ local targets   = grafana.targets;
       datasource    = ds.cloudwatch,
       namespace     = 'AWS/RDS',
       metricName    = 'CPUUtilization',
+      dimensions  = {
+        DBClusterIdentifier: vars.rds_cluster_id,
+      },
+      matchExact  = true,
       statistic     = 'Average',
       refId         = 'CPU_Avg'
     ))

--- a/terraform/monitoring/panels/rds/database_connections.libsonnet
+++ b/terraform/monitoring/panels/rds/database_connections.libsonnet
@@ -16,6 +16,10 @@ local targets   = grafana.targets;
       datasource    = ds.cloudwatch,
       namespace     = 'AWS/RDS',
       metricName    = 'DatabaseConnections',
+      dimensions  = {
+        DBClusterIdentifier: vars.rds_cluster_id,
+      },
+      matchExact  = true,
       statistic     = 'Average',
     ))
 }

--- a/terraform/monitoring/panels/rds/freeable_memory.libsonnet
+++ b/terraform/monitoring/panels/rds/freeable_memory.libsonnet
@@ -37,6 +37,10 @@ local targets   = grafana.targets;
       datasource    = ds.cloudwatch,
       namespace     = 'AWS/RDS',
       metricName    = 'FreeableMemory',
+      dimensions  = {
+        DBClusterIdentifier: vars.rds_cluster_id,
+      },
+      matchExact  = true,
       statistic     = 'Average',
       refId         = 'Mem_Avg',
     ))

--- a/terraform/monitoring/panels/rds/volume_bytes_used.libsonnet
+++ b/terraform/monitoring/panels/rds/volume_bytes_used.libsonnet
@@ -19,6 +19,10 @@ local targets   = grafana.targets;
       datasource    = ds.cloudwatch,
       namespace     = 'AWS/RDS',
       metricName    = 'VolumeBytesUsed',
+      dimensions  = {
+        DBClusterIdentifier: vars.rds_cluster_id,
+      },
+      matchExact  = true,
       statistic     = 'Average',
     ))
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -28,6 +28,11 @@ variable "ecs_target_group_arn" {
   type        = string
 }
 
+variable "rds_cluster_id" {
+  description = "The cluster ID of the RDS cluster."
+  type        = string
+}
+
 variable "redis_cluster_id" {
   description = "The cluster ID of the Redis cluster."
   type        = string

--- a/terraform/res_monitoring.tf
+++ b/terraform/res_monitoring.tf
@@ -9,6 +9,7 @@ module "monitoring" {
 
   ecs_cluster_name     = module.ecs.ecs_cluster_name
   ecs_service_name     = module.ecs.ecs_service_name
+  rds_cluster_id       = module.postgres.rds_cluster_id
   ecs_target_group_arn = module.ecs.target_group_arn
   redis_cluster_id     = module.redis.cluster_id
   load_balancer_arn    = module.ecs.load_balancer_arn_suffix


### PR DESCRIPTION
# Description

Fixes that the RDS charts include databases that aren't part of this TF deployment (e.g. manual clones).

## How Has This Been Tested?

Somewhat manually via Grafana.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
