### PR TITLE
fix: raise RDS CPU alarm threshold, tests, extra logging

### DIFF
--- a/src/services/public_http_server/handlers/notify_v1.rs
+++ b/src/services/public_http_server/handlers/notify_v1.rs
@@ -222,7 +222,10 @@ pub async fn handler_impl(
         )
         .await?;
         if subscriber_ids.len() == SUBSCRIBER_NOTIFICATION_COUNT_LIMIT {
-            info!("Maximum upsert_subscriber_notifications sample, latency {:?}", start.elapsed());
+            info!(
+                "Maximum upsert_subscriber_notifications sample, latency {:?}",
+                start.elapsed()
+            );
         }
 
         if accounts.len() != response.sent.len() + response.not_found.len() + response.failed.len()

--- a/src/services/public_http_server/handlers/notify_v1.rs
+++ b/src/services/public_http_server/handlers/notify_v1.rs
@@ -213,6 +213,7 @@ pub async fn handler_impl(
             response.sent.insert(account);
         }
 
+        let start = Instant::now();
         upsert_subscriber_notifications(
             notification.id,
             &subscriber_ids,
@@ -220,6 +221,9 @@ pub async fn handler_impl(
             state.metrics.as_ref(),
         )
         .await?;
+        if subscriber_ids.len() == SUBSCRIBER_NOTIFICATION_COUNT_LIMIT {
+            info!("Maximum upsert_subscriber_notifications sample, latency {:?}", start.elapsed());
+        }
 
         if accounts.len() != response.sent.len() + response.not_found.len() + response.failed.len()
         {

--- a/src/types/notification.rs
+++ b/src/types/notification.rs
@@ -26,7 +26,7 @@ impl Notification {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, serde_json::json};
 
     #[test]
     fn valid_notification() {
@@ -92,5 +92,15 @@ mod test {
         }
         .validate()
         .is_err());
+    }
+
+    #[test]
+    fn optional_fields() {
+        serde_json::from_value::<Notification>(json!({
+            "type": Uuid::new_v4(),
+            "title": "title",
+            "body": "body"
+        }))
+        .unwrap();
     }
 }

--- a/terraform/monitoring/panels/rds/cpu.libsonnet
+++ b/terraform/monitoring/panels/rds/cpu.libsonnet
@@ -20,7 +20,7 @@ local targets   = grafana.targets;
         title         = 'RDS',
         notifications = vars.notifications,
         refid         = 'CPU',
-        limit         = 70,
+        limit         = 90,
         reducer       = grafana.alertCondition.reducers.Max,
       )
     )


### PR DESCRIPTION
# Description

- Raises RDS CPU alarm from max 70% to 90%
- Adds test case that optional notification fields are indeed optional
- Logs an info whenever we are inserting the allowed maximum number of subscriber notifications to analyze its performance and if the limit should be increased

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
