### PR TITLE
feat: increasing publishing workers count to 50

### DIFF
--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -39,9 +39,9 @@ pub mod types;
 
 // TODO: These should be configurable, add to the config
 /// Maximum of the parallel messages processing workers
-const MAX_WORKERS: usize = 30;
+const MAX_WORKERS: usize = 50;
 /// Number of workers to be spawned on the service start to clean the queue
-const START_WORKERS: usize = 30;
+const START_WORKERS: usize = 50;
 // Messages queue stats observing database polling interval
 const QUEUE_STATS_POLLING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 /// Maximum publishing time before the publish will be considered as failed


### PR DESCRIPTION
# Description

This PR increased the number of publishing workers from `30` to `50`.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
