### PR TITLE
fix: ensure subscription to project topic

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -25,6 +25,7 @@ use {
 pub struct ProjectWithPublicKeys {
     pub authentication_public_key: String,
     pub subscribe_public_key: String,
+    pub topic: String,
 }
 
 pub async fn upsert_project(
@@ -82,7 +83,7 @@ async fn upsert_project_impl(
         ON CONFLICT (project_id) DO UPDATE SET
             updated_at=now(),
             app_domain=$2
-        RETURNING authentication_public_key, subscribe_public_key
+        RETURNING authentication_public_key, subscribe_public_key, topic
     ";
     let start = Instant::now();
     let result = sqlx::query_as::<Postgres, ProjectWithPublicKeys>(query)


### PR DESCRIPTION
# Description

Fixes that project topic from the database wasn't being used to subscribe to, and also sends a noop tag to ensure the relay topic will last for 30 days instead of just 5 minutes.

## How Has This Been Tested?

New test

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
