### PR TITLE
chore: rename charts

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -82,7 +82,7 @@ dashboard.new(
     panels.app.relay_subscribe_latency(ds, vars)                    {gridPos: pos._6 },
     panels.app.relay_subscribe_failures(ds, vars)                   {gridPos: pos._6 },
 
-  row.new('Application publisher subservice'),
+  row.new('Notification publisher background service'),
     panels.app.publishing_workers_count(ds, vars)                   {gridPos: pos._5 },
     panels.app.publishing_workers_errors(ds, vars)                  {gridPos: pos._5 },
     panels.app.publishing_workers_queued_size(ds, vars)             {gridPos: pos._5 },

--- a/terraform/monitoring/panels/app/publishing_workers_count.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_count.libsonnet
@@ -7,7 +7,7 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Publishing worker tasks count',
+      title       = 'Worker count',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)

--- a/terraform/monitoring/panels/app/publishing_workers_errors.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_errors.libsonnet
@@ -7,7 +7,7 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Publishing worker tasks errors count',
+      title       = 'Error rate',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)

--- a/terraform/monitoring/panels/app/publishing_workers_processing_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_processing_size.libsonnet
@@ -7,7 +7,7 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Messages in processing state',
+      title       = 'status=processing count',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)

--- a/terraform/monitoring/panels/app/publishing_workers_published_count.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_published_count.libsonnet
@@ -7,7 +7,7 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Published messages count',
+      title       = 'Publish rate',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)

--- a/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
+++ b/terraform/monitoring/panels/app/publishing_workers_queued_size.libsonnet
@@ -7,7 +7,7 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Messages queue size',
+      title       = 'Queue size',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)


### PR DESCRIPTION
# Description

Renames the publishing workers charts to be a little bit friendlier

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
