### PR TITLE
fix: publish noop to existing project topics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "terraform/monitoring/grafonnet-lib"]
 	path = terraform/monitoring/grafonnet-lib
 	url = git@github.com:WalletConnect/grafonnet-lib.git
+[submodule "rs-relay"]
+	path = rs-relay
+	url = git@github.com:WalletConnect/rs-relay.git

--- a/src/publish_relay_message.rs
+++ b/src/publish_relay_message.rs
@@ -13,15 +13,16 @@ use {
         time::{Duration, Instant},
     },
     tokio::time::sleep,
-    tracing::{error, instrument, warn},
+    tracing::{error, info, instrument, warn},
 };
 
-#[instrument(skip_all)]
+#[instrument(skip(relay_http_client, metrics))]
 pub async fn publish_relay_message(
     relay_http_client: &Client,
     publish: &Publish,
     metrics: Option<&Metrics>,
 ) -> Result<(), Error> {
+    info!("publish_relay_message");
     let start = Instant::now();
 
     let client_publish_call = || async {
@@ -89,12 +90,13 @@ pub async fn publish_relay_message(
     Ok(())
 }
 
-#[instrument(skip_all)]
+#[instrument(skip(relay_ws_client, metrics))]
 pub async fn subscribe_relay_topic(
     relay_ws_client: &relay_client::websocket::Client,
     topic: &Topic,
     metrics: Option<&Metrics>,
 ) -> Result<(), Error> {
+    info!("subscribe_relay_topic");
     let start = Instant::now();
 
     let client_publish_call = || async {
@@ -147,6 +149,8 @@ pub async fn extend_subscription_ttl(
     topic: Topic,
     metrics: Option<&Metrics>,
 ) -> Result<(), Error> {
+    info!("extend_subscription_ttl");
+
     // Extremely minor performance optimization with OnceLock to avoid allocating the same empty string everytime
     static LOCK: OnceLock<Arc<str>> = OnceLock::new();
     let message = LOCK.get_or_init(|| "".into()).clone();

--- a/src/services/public_http_server/handlers/subscribe_topic.rs
+++ b/src/services/public_http_server/handlers/subscribe_topic.rs
@@ -103,8 +103,15 @@ pub async fn handler(
     info!("Subscribing to project topic: {topic}");
     subscribe_relay_topic(&state.relay_ws_client, &topic, state.metrics.as_ref()).await?;
 
-    extend_subscription_ttl(&state.relay_http_client, topic, state.metrics.as_ref()).await?;
+    info!("Extending subscription TTL");
+    extend_subscription_ttl(
+        &state.relay_http_client,
+        topic.clone(),
+        state.metrics.as_ref(),
+    )
+    .await?;
 
+    info!("Successfully subscribed to project topic: {topic}");
     Ok(Json(SubscribeTopicResponseBody {
         authentication_key: project.authentication_public_key,
         subscribe_key: project.subscribe_public_key,


### PR DESCRIPTION
# Description

When https://github.com/WalletConnect/notify-server/pull/333 was shipped it didn't account for existing projects. The assumption was that projects could fix by performing `subscribe-topic`, however this is a long tail so should be fixed for good.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
