### PR TITLE
fix: test with local relay

### DIFF
--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -115,4 +115,4 @@ jobs:
         uses: WalletConnect/actions-rs/cargo@1.1.0
         with:
           command: test
-          args: --test integration -- --test-threads=1
+          args: --test integration

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -104,7 +104,7 @@ jobs:
           run: |
             echo "${{ env.RELAY_DOT_ENV }}" | base64 -d > .env
             source .env
-            cargo run &
+            just run &
           wait-on: |
             tcp:127.0.0.1:8888
           log-output-if: true

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -84,14 +84,22 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
+      - name: Build Relay
+        run: |
+          cargo build
+        working-directory: rs-relay
+
+      - name: Start relay dependencies
+        run: |
+          just run-storage-docker
+        working-directory: rs-relay
+
       - uses: JarvusInnovations/background-action@v1
         name: Start Relay
         with:
           run: |
             echo "${{ env.RELAY_DOT_ENV }}" | base64 -d > .env
             source .env
-            cargo build
-            just run-storage-docker
             cargo run &
           wait-on: |
             127.0.0.1:8888

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Install Rust ${{ vars.RUST_VERSION }}
         uses: WalletConnect/actions-rs/toolchain@1.1.0

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -94,6 +94,7 @@ jobs:
 
       - name: Start relay dependencies
         run: |
+          cargo install just
           just run-storage-docker
         working-directory: rs-relay
 

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -107,8 +107,7 @@ jobs:
             cargo run &
           wait-on: |
             tcp:127.0.0.1:8888
-          log-output-resume: stderr
-          log-output-if: failure
+          log-output-if: true
           working-directory: rs-relay
 
       - name: Integration Tests

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Install Rust ${{ vars.RUST_VERSION }}
         uses: WalletConnect/actions-rs/toolchain@1.1.0

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -40,6 +40,7 @@ jobs:
       group: ${{ vars.RUN_GROUP }}
     env:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
+      RELAY_DOT_ENV: ${{ secrets.RELAY_DOT_ENV }}
     services:
       postgres:
         image: postgres:16
@@ -56,7 +57,7 @@ jobs:
       redis:
         image: redis:7-alpine
         ports:
-          - 6379:6379
+          - 6378:6379
     steps:
       # https://github.com/orgs/community/discussions/26688#discussioncomment-3252882
       - name: "Set some postgres settings"
@@ -82,6 +83,21 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
+
+      - uses: JarvusInnovations/background-action@v1
+        name: Start Relay
+        with:
+          run: |
+            echo "${{ env.RELAY_DOT_ENV }}" | base64 -d > .env
+            source .env
+            cargo build
+            just run-storage-docker
+            cargo run &
+          wait-on: |
+            127.0.0.1:8888
+          log-output-resume: stderr
+          log-output-if: failure
+          working-directory: rs-relay
 
       - name: Integration Tests
         uses: WalletConnect/actions-rs/cargo@1.1.0

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -106,7 +106,7 @@ jobs:
             source .env
             cargo run &
           wait-on: |
-            127.0.0.1:8888
+            tcp:127.0.0.1:8888
           log-output-resume: stderr
           log-output-if: failure
           working-directory: rs-relay

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "terraform/monitoring/grafonnet-lib"]
 	path = terraform/monitoring/grafonnet-lib
 	url = git@github.com:WalletConnect/grafonnet-lib.git
-[submodule "rs-relay"]
-	path = rs-relay
-	url = git@github.com:WalletConnect/rs-relay.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "terraform/monitoring/grafonnet-lib"]
 	path = terraform/monitoring/grafonnet-lib
 	url = git@github.com:WalletConnect/grafonnet-lib.git
+[submodule "rs-relay"]
+	path = rs-relay
+	url = git@github.com:WalletConnect/rs-relay.git

--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@
 
 ## Development
 
+### Dependencies
+
+- Rust
+- just
+- docker
+
+```bash
+git submodule update --init --recursive
+```
+
+### Running the relay locally
+
+```bash
+cd rs-relay
+# update .env file
+source .env
+just run-storage-docker
+cargo run
+```
+
 ### Devloop
 
 Runs all tests, integration tests, and deployment tests automatically.

--- a/README.md
+++ b/README.md
@@ -19,16 +19,6 @@
 git submodule update --init --recursive
 ```
 
-### Running the relay locally
-
-```bash
-cd rs-relay
-# update .env file
-source .env
-just run-storage-docker
-cargo run
-```
-
 ### Devloop
 
 Runs all tests, integration tests, and deployment tests automatically.

--- a/docker-compose.storage.yml
+++ b/docker-compose.storage.yml
@@ -10,7 +10,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-    - "6379:6379"
+    - "6378:6379"
 
   postgres:
     image: postgres:16

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ test-all:
 
 test-integration:
   @echo '==> Testing integration'
-  RUST_BACKTRACE=1 ANSI_LOGS=true cargo test --test integration -- {{test}} --test-threads=1
+  RUST_BACKTRACE=1 ANSI_LOGS=true cargo test --test integration -- {{test}}
 
 # Clean build artifacts
 clean:

--- a/justfile
+++ b/justfile
@@ -45,10 +45,19 @@ unit: lint test test-all lint-tf
 
 devloop: unit fmt-imports
   #!/bin/bash -eux
+  trap 'jobs -lp | xargs -L 1 pkill -SIGINT -P' EXIT
+
+  pushd rs-relay
+  just run-storage-docker build
+  source .env
+  just run &
+  while ! nc -z 127.0.0.1 8888; do sleep 1; done
+  popd
+
   just run-storage-docker test-integration
   just run &
-  trap 'pkill -SIGINT -P $(jobs -pr)' EXIT
-  sleep 1 # wait for `run` to start
+  while ! nc -z 127.0.0.1 3000; do sleep 1; done
+
   just test-deployment
   echo "✅ Success! ✅"
 

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -52,7 +52,7 @@ pub fn default_postgres_url() -> String {
 }
 
 pub fn default_redis_url() -> String {
-    "redis://localhost:6379/0".to_owned()
+    "redis://localhost:6378/0".to_owned()
 }
 
 pub fn default_postgres_max_connections() -> u32 {
@@ -64,7 +64,7 @@ fn default_keypair_seed() -> String {
 }
 
 fn default_relay_url() -> Url {
-    "wss://staging.relay.walletconnect.com".parse().unwrap()
+    "ws://127.0.0.1:8888".parse().unwrap()
 }
 
 fn default_registry_url() -> Url {

--- a/src/registry/storage/redis/mod.rs
+++ b/src/registry/storage/redis/mod.rs
@@ -11,7 +11,7 @@ use {
     std::{fmt::Debug, time::Duration},
 };
 
-const LOCAL_REDIS_ADDR: &str = "redis://localhost:6379/0";
+const LOCAL_REDIS_ADDR: &str = "redis://localhost:6378/0";
 
 #[derive(Debug, Clone)]
 pub enum Addr<'a> {

--- a/tests/deployment.rs
+++ b/tests/deployment.rs
@@ -132,7 +132,7 @@ fn get_vars() -> Vars {
         },
         "LOCAL" => Vars {
             notify_url: "http://127.0.0.1:3000".to_owned(),
-            relay_url: "wss://staging.relay.walletconnect.com".to_owned(),
+            relay_url: "ws://127.0.0.1:8888".to_owned(),
             relay_project_id,
             notify_project_id: notify_prod_project_id(),
             notify_project_secret: notify_prod_project_secret(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -99,6 +99,7 @@ use {
     rand::rngs::StdRng,
     rand_chacha::rand_core::OsRng,
     rand_core::SeedableRng,
+    // regex::Regex,
     relay_rpc::{
         auth::{
             cacao::{
@@ -164,7 +165,7 @@ fn get_vars() -> Vars {
         project_id: env::var("PROJECT_ID").unwrap(),
 
         // No use-case to modify these currently.
-        relay_url: "wss://relay.walletconnect.com".to_owned(),
+        relay_url: "ws://127.0.0.1:8888".to_owned(),
     }
 }
 
@@ -979,8 +980,8 @@ impl AsyncTestContext for NotifyServerContext {
             relay_url: vars.relay_url.parse().unwrap(),
             notify_url: notify_url.clone(),
             registry_auth_token: "".to_owned(),
-            auth_redis_addr_read: Some("redis://localhost:6379/0".to_owned()),
-            auth_redis_addr_write: Some("redis://localhost:6379/0".to_owned()),
+            auth_redis_addr_read: Some("redis://localhost:6378/0".to_owned()),
+            auth_redis_addr_write: Some("redis://localhost:6378/0".to_owned()),
             redis_pool_size: 1,
             telemetry_prometheus_port: Some(telemetry_prometheus_port),
             s3_endpoint: None,
@@ -1031,6 +1032,7 @@ impl AsyncTestContext for NotifyServerContext {
             redis,
             registry_mock_server,
             clock,
+            // cloudflared,
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1032,7 +1032,6 @@ impl AsyncTestContext for NotifyServerContext {
             redis,
             registry_mock_server,
             clock,
-            // cloudflared,
         }
     }
 


### PR DESCRIPTION
# Description

Builds and runs rs-relay locally and uses it for tests instead of the deployed relay. This sets the stage for switching to webhooks for incoming relay messages.

This seems to greatly improve on test flakyness.

## How Has This Been Tested?

Existing tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
