### PR TITLE
fix: pick notification race condition

### DIFF
--- a/src/services/publisher_service/helpers.rs
+++ b/src/services/publisher_service/helpers.rs
@@ -128,9 +128,11 @@ pub async fn pick_subscriber_notification_for_processing(
             FROM subscriber_notification
             WHERE status='queued'
             LIMIT 1
+            FOR UPDATE SKIP LOCKED
         )
         UPDATE subscriber_notification
-        SET status='processing'
+        SET updated_at=now(),
+            status='processing'
         FROM picked
         WHERE subscriber_notification.id=picked.id
         RETURNING picked.id


### PR DESCRIPTION
# Description

[Context](https://walletconnect.slack.com/archives/C04JHSB53MK/p1706457674290119?thread_ts=1706041983.546179&cid=C04JHSB53MK)

Prevents a race condition in picking a notification to send where the same notification can be picked up by multiple workers before it is marked as processing.

Also adds the missing update_at change which regressed when I rewrote the query.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
