### PR TITLE
fix: tfdocs indent

### DIFF
--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     name: /
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.1.2
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@fix/private-submodule
     with:
       check-infra: ${{ inputs.check-infra }}
       check-app: ${{ inputs.check-app }}

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     name: /
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@fix/private-submodule
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.1
     with:
       check-infra: ${{ inputs.check-infra }}
       check-app: ${{ inputs.check-app }}

--- a/terraform/.terraform-docs.yml
+++ b/terraform/.terraform-docs.yml
@@ -22,19 +22,19 @@ content: |
   {{- $hideInputs := list "namespace" "region" "stage" "name" "delimiter" "attributes" "tags" "regex_replace_chars" "id_length_limit" "label_key_case" "label_value_case" "label_order" }}
   {{- $filteredInputs := list -}}
   {{- range .Module.Inputs -}}
-      {{- if not (has .Name $hideInputs) -}}
-          {{- $filteredInputs = append $filteredInputs . -}}
-      {{- end -}}
+    {{- if not (has .Name $hideInputs) -}}
+        {{- $filteredInputs = append $filteredInputs . -}}
+    {{- end -}}
   {{- end -}}
   {{ if not $filteredInputs }}
 
     No inputs.
   {{ else }}
-    | Name | Description | Type | Default | Required |
-    |------|-------------|------|---------|:--------:|
-    {{- range $filteredInputs }}
-        | {{ anchorNameMarkdown "input" .Name }} | {{ tostring .Description | sanitizeMarkdownTbl }} | {{ printf " " }}<pre lang="json">{{ tostring .Type | sanitizeMarkdownTbl }}</pre> | {{ printf " " }}<pre lang="json">{{ .GetValue | sanitizeMarkdownTbl }}</pre> | {{ printf " " }}{{ ternary .Required "yes" "no" }} |
-    {{- end }}
+  | Name | Description | Type | Default | Required |
+  |------|-------------|------|---------|:--------:|
+  {{- range $filteredInputs }}
+  | {{ anchorNameMarkdown "input" .Name }} | {{ tostring .Description | sanitizeMarkdownTbl }} | {{ printf " " }}<pre lang="json">{{ tostring .Type | sanitizeMarkdownTbl }}</pre> | {{ printf " " }}<pre lang="json">{{ .GetValue | sanitizeMarkdownTbl }}</pre> | {{ printf " " }}{{ ternary .Required "yes" "no" }} |
+  {{- end }}
   {{- end }}
   {{ .Outputs }}
   {{/** End of file fixer */}}

--- a/terraform/.terraform-docs.yml
+++ b/terraform/.terraform-docs.yml
@@ -22,9 +22,9 @@ content: |
   {{- $hideInputs := list "namespace" "region" "stage" "name" "delimiter" "attributes" "tags" "regex_replace_chars" "id_length_limit" "label_key_case" "label_value_case" "label_order" }}
   {{- $filteredInputs := list -}}
   {{- range .Module.Inputs -}}
-    {{- if not (has .Name $hideInputs) -}}
-        {{- $filteredInputs = append $filteredInputs . -}}
-    {{- end -}}
+      {{- if not (has .Name $hideInputs) -}}
+          {{- $filteredInputs = append $filteredInputs . -}}
+      {{- end -}}
   {{- end -}}
   {{ if not $filteredInputs }}
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -64,5 +64,4 @@ To authenticate, run `terraform login` and follow the instructions.
 
 No outputs.
 
-
 <!-- END_TF_DOCS -->

--- a/terraform/alerting/README.md
+++ b/terraform/alerting/README.md
@@ -41,5 +41,4 @@ This module configures the alarms and webhook forwarding.
 
 No outputs.
 
-
 <!-- END_TF_DOCS -->

--- a/terraform/docdb/README.md
+++ b/terraform/docdb/README.md
@@ -65,5 +65,4 @@ Creates a DocumentDB cluster with auto-scaled read replicas.
 | <a name="output_port"></a> [port](#output\_port) | The connection port |
 | <a name="output_username"></a> [username](#output\_username) | The master username |
 
-
 <!-- END_TF_DOCS -->

--- a/terraform/ecs/README.md
+++ b/terraform/ecs/README.md
@@ -83,5 +83,4 @@ This module creates an ECS cluster and an autoscaling group of EC2 instances to 
 | <a name="output_service_security_group_id"></a> [service\_security\_group\_id](#output\_service\_security\_group\_id) | The ID of the security group for the service |
 | <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | The ARN of the target group |
 
-
 <!-- END_TF_DOCS -->

--- a/terraform/monitoring/README.md
+++ b/terraform/monitoring/README.md
@@ -35,10 +35,10 @@ Configure the Grafana dashboards for the application
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN of the monitoring role. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The notification channels to send alerts to |  <pre lang="json">list(any)</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_prometheus_endpoint"></a> [prometheus\_endpoint](#input\_prometheus\_endpoint) | The endpoint for the Prometheus server. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
+| <a name="input_rds_cluster_id"></a> [rds\_cluster\_id](#input\_rds\_cluster\_id) | The cluster ID of the RDS cluster. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_redis_cluster_id"></a> [redis\_cluster\_id](#input\_redis\_cluster\_id) | The cluster ID of the Redis cluster. |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 ## Outputs
 
 No outputs.
-
 
 <!-- END_TF_DOCS -->

--- a/terraform/postgres/README.md
+++ b/terraform/postgres/README.md
@@ -51,5 +51,4 @@ This module creates a Postgres RDS cluster with IAM authentication.
 | <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | The cluster endpoint |
 | <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the cluster |
 
-
 <!-- END_TF_DOCS -->

--- a/terraform/redis/README.md
+++ b/terraform/redis/README.md
@@ -39,5 +39,4 @@ This module creates a Redis database.
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The ID of the cluster |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The endpoint of the Redis cluster |
 
-
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
# Description

Fixes that in the latest Terraform version the Markdown table would have lots of whitespace prefixing the lines.

[Context](https://walletconnect.slack.com/archives/C068RRL89HC/p1706311832813029)

Depends on https://github.com/WalletConnect/ci_workflows/pull/1

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
