### PR TITLE
fix: only run renew operation one at a time

### DIFF
--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -31,7 +31,7 @@ jobs:
   cd-staging:
     name: Staging
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.2
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.3
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
@@ -56,7 +56,7 @@ jobs:
     needs: [ validate-staging ]
     if: ${{ inputs.deploy-prod }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.2
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.3
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     name: /
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@fix/udeps-use-stable
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.3
     with:
       check-infra: ${{ inputs.check-infra }}
       check-app: ${{ inputs.check-app }}

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     name: /
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.2
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@fix/udeps-use-stable
     with:
       check-infra: ${{ inputs.check-infra }}
       check-app: ${{ inputs.check-app }}

--- a/src/services/websocket_server/mod.rs
+++ b/src/services/websocket_server/mod.rs
@@ -30,7 +30,7 @@ use {
     sha2::Sha256,
     sqlx::PgPool,
     std::{convert::Infallible, sync::Arc, time::Instant},
-    tokio::sync::mpsc::UnboundedReceiver,
+    tokio::sync::{mpsc::UnboundedReceiver, Mutex},
     tracing::{error, info, instrument, warn},
     wc::metrics::otel::Context,
 };
@@ -63,6 +63,7 @@ async fn connect(state: &AppState, client: &Client) -> Result<(), NotifyServerEr
         client,
         &state.relay_http_client,
         state.metrics.as_ref(),
+        state.resubscribe_all_topics_lock.clone(),
     )
     .await?;
 
@@ -153,6 +154,7 @@ async fn resubscribe(
     client: &Client,
     relay_http_client: &Arc<relay_client::http::Client>,
     metrics: Option<&Metrics>,
+    resubscribe_all_topics_lock: Arc<Mutex<bool>>,
 ) -> Result<(), NotifyServerError> {
     info!("Resubscribing to all topics");
     let start = Instant::now();
@@ -198,18 +200,23 @@ async fn resubscribe(
     let elapsed: u64 = start.elapsed().as_millis().try_into().unwrap();
     info!("resubscribe took {elapsed}ms");
 
-    // Renew all subscription TTLs.
-    // This can take a long time (e.g. up to 1 hour), so cannot block server startup.
-    tokio::task::spawn({
-        let client = client.clone();
-        let relay_http_client = relay_http_client.clone();
-        let metrics = metrics.cloned();
-        async move {
-            let client = &client;
-            let relay_http_client = &relay_http_client;
-            let metrics = metrics.as_ref();
-            let start = Instant::now();
-            let result = futures_util::stream::iter(topics)
+    // If operation already running, don't start another one
+    let mut operation_running = resubscribe_all_topics_lock.lock().await;
+    if *operation_running {
+        *operation_running = true;
+        // Renew all subscription TTLs.
+        // This can take a long time (e.g. 2 hours), so cannot block server startup.
+        tokio::task::spawn({
+            let client = client.clone();
+            let relay_http_client = relay_http_client.clone();
+            let metrics = metrics.cloned();
+            let resubscribe_all_topics_lock = resubscribe_all_topics_lock.clone();
+            async move {
+                let client = &client;
+                let relay_http_client = &relay_http_client;
+                let metrics = metrics.as_ref();
+                let start = Instant::now();
+                let result = futures_util::stream::iter(topics)
                 .map(|topic| async move {
                     // Subscribe a second time as the initial subscription above may have expired
                     subscribe_relay_topic(client, &topic, metrics)
@@ -223,20 +230,22 @@ async fn resubscribe(
                 })
                 // Above we want to resubscribe as quickly as possible so use a high concurrency value
                 // But here we prefer stability and are OK with a lower value
-                .buffer_unordered(50)
+                .buffer_unordered(25)
                 .try_collect::<Vec<_>>()
                 .await;
-            let elapsed: u64 = start.elapsed().as_millis().try_into().unwrap();
-            if let Err(e) = result {
-                // An error here is bad, as topics will not have been renewed.
-                // However, this should be rare and many resubscribes will happen within 30 days so all topics should be renewed eventually.
-                // With <https://github.com/WalletConnect/notify-server/issues/325> we will be able to guarantee renewal much better.
-                error!("Failed to renew all topic subscriptions in {elapsed}ms: {e}");
-            } else {
-                info!("Success renewing all topic subscriptions in {elapsed}ms");
+                let elapsed: u64 = start.elapsed().as_millis().try_into().unwrap();
+                if let Err(e) = result {
+                    // An error here is bad, as topics will not have been renewed.
+                    // However, this should be rare and many resubscribes will happen within 30 days so all topics should be renewed eventually.
+                    // With <https://github.com/WalletConnect/notify-server/issues/325> we will be able to guarantee renewal much better.
+                    error!("Failed to renew all topic subscriptions in {elapsed}ms: {e}");
+                } else {
+                    info!("Success renewing all topic subscriptions in {elapsed}ms");
+                }
+                *resubscribe_all_topics_lock.lock().await = false;
             }
-        }
-    });
+        });
+    }
 
     if let Some(metrics) = metrics {
         let ctx = Context::current();

--- a/src/services/websocket_server/mod.rs
+++ b/src/services/websocket_server/mod.rs
@@ -202,7 +202,7 @@ async fn resubscribe(
 
     // If operation already running, don't start another one
     let mut operation_running = resubscribe_all_topics_lock.lock().await;
-    if *operation_running {
+    if !*operation_running {
         *operation_running = true;
         // Renew all subscription TTLs.
         // This can take a long time (e.g. 2 hours), so cannot block server startup.

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,7 +33,7 @@ pub struct AppState {
     pub notify_keys: NotifyKeys,
     pub clock: Clock,
     pub provider: BlockchainApiProvider,
-    pub resubscribe_all_topics_lock: Arc<Mutex<bool>>,
+    pub renew_all_topics_lock: Arc<Mutex<bool>>,
 }
 
 build_info::build_info!(fn build_info);
@@ -72,7 +72,7 @@ impl AppState {
             notify_keys,
             clock,
             provider,
-            resubscribe_all_topics_lock: Arc::new(Mutex::new(false)),
+            renew_all_topics_lock: Arc::new(Mutex::new(false)),
         })
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@ use {
     serde::{Deserialize, Serialize},
     sqlx::PgPool,
     std::{fmt, sync::Arc},
+    tokio::sync::Mutex,
     tracing::info,
 };
 
@@ -32,6 +33,7 @@ pub struct AppState {
     pub notify_keys: NotifyKeys,
     pub clock: Clock,
     pub provider: BlockchainApiProvider,
+    pub resubscribe_all_topics_lock: Arc<Mutex<bool>>,
 }
 
 build_info::build_info!(fn build_info);
@@ -70,6 +72,7 @@ impl AppState {
             notify_keys,
             clock,
             provider,
+            resubscribe_all_topics_lock: Arc::new(Mutex::new(false)),
         })
     }
 


### PR DESCRIPTION
# Description

[This PR](https://github.com/WalletConnect/notify-server/pull/349) fixed that topic subscriptions may expire after a period of time, however it allowed this renewal operation to run in parallel. However in-parallel can result in high levels of load on the relay and we don't need it to run in parallel.

This PR prevents this from running in parallel if one operation is already running.

[Slack conversation](https://walletconnect.slack.com/archives/C058RS0MH38/p1707250697304959?thread_ts=1707250104.976949&cid=C058RS0MH38)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
