### PR TITLE
fix: don't block startup on subscribe

### DIFF
--- a/src/services/relay_renewal_job/refresh_topic_subscriptions.rs
+++ b/src/services/relay_renewal_job/refresh_topic_subscriptions.rs
@@ -63,6 +63,9 @@ pub async fn run(
             async move {
                 let client = &client;
                 let metrics = metrics.as_ref();
+
+                // Using `batch_subscription` was removed in https://github.com/WalletConnect/notify-server/pull/359
+                // We can't really use this right now because we are also extending the topic TTL which could take longer than the 5m TTL
                 let result = futures_util::stream::iter(topics)
                     .map(|topic| async move {
                         // Subscribe a second time as the initial subscription above may have expired


### PR DESCRIPTION
# Description

Removes the blocking subscribe from startup. Because we've switched to webhooks, we do not need to associate the subscription with the websocket, and the relay will remember the subscription for 30 days. We still need to renew, so that async job is still there. This will be improved with #325 

Improving startup time allows the service to start, which apparently it isn't starting anymore due to the length of time it takes to subscribe being longer than the healthcheck allowance: https://walletconnect.slack.com/archives/C058RS0MH38/p1707770358630189?thread_ts=1707766935.771459&cid=C058RS0MH38

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
