### PR TITLE
fix: use common log for HTTP errors

### DIFF
--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -68,11 +68,12 @@ pub enum Error {
     ServerError(RelayMessageServerError),
 }
 
+// TODO consider using unified error.rs for sharing warn vs error prefixes (i.e. HTTP server error)
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {
             Error::ClientError(e) => {
-                warn!("Relay webhook client error: {e:?}");
+                warn!("HTTP client error: Relay webhook client error: {e:?}");
                 (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     Json(json!({ "error": e.to_string() })),
@@ -80,7 +81,7 @@ impl IntoResponse for Error {
                     .into_response()
             }
             Error::ServerError(e) => {
-                error!("Relay webhook server error: {e:?}");
+                error!("HTTP server error: Relay webhook server error: {e:?}");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(json!({ "error": "Internal server error" })),


### PR DESCRIPTION
# Description

Searching for why a 5xx happened should be easy. I search for "HTTP server error" but the relay webhook was doing a different error response than the main error handler.

In the future we should share the same `IntoResponse for Error` as the other HTTP endpoints, but for now just re-using the same string prefix.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
