### PR TITLE
fix: log if an address is ERC-55 or not

### DIFF
--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -5,6 +5,7 @@ use {
     sha2::Digest,
     sha3::Keccak256,
     std::sync::Arc,
+    tracing::info,
 };
 
 #[derive(
@@ -48,7 +49,12 @@ impl TryFrom<&str> for AccountId {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         if is_eip155_account(s) {
-            Ok(Self(Arc::from(ensure_erc_55(s))))
+            let erc55 = ensure_erc_55(s);
+            info!(
+                "Address is {}ERC-55 compliant",
+                if erc55 == s { "" } else { "not " }
+            );
+            Ok(Self(Arc::from(erc55)))
         } else {
             Err(AccountIdError)
         }


### PR DESCRIPTION
# Description

Resolves #364 

We should be enforcing ERC-55 not normalizing to it. Log if there is non-compliance at all and if we are safe to enforce.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
