### PR TITLE
fix: enforce ERC-55 addresses

### DIFF
--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -87,12 +87,12 @@ pub enum Eip155Error {
 fn is_valid_eip155_account(account_id: &str) -> Result<(), Eip155Error> {
     static PATTERN_CELL: OnceCell<regex::Regex> = OnceCell::new();
     let pattern = PATTERN_CELL
-        .get_or_init(|| regex::Regex::new(r"^eip155:\d+:0x(?<address>[0-9a-fA-F]{40})$").unwrap());
+        .get_or_init(|| regex::Regex::new(r"^eip155:\d+:0x([0-9a-fA-F]{40})$").unwrap());
 
     if let Some(caps) = pattern.captures(account_id) {
-        let address = &caps["address"];
+        let (_, [address]) = &caps.extract();
         let erc55 = erc_55_checksum_encode(&address.to_ascii_lowercase()).collect::<String>();
-        if erc55 == address {
+        if &erc55 == address {
             Ok(())
         } else {
             Err(Eip155Error::Erc55)

--- a/src/model/types/account_id.rs
+++ b/src/model/types/account_id.rs
@@ -5,6 +5,7 @@ use {
     sha2::Digest,
     sha3::Keccak256,
     std::sync::Arc,
+    thiserror::Error,
 };
 
 #[derive(
@@ -31,13 +32,13 @@ impl AccountId {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum AccountIdError {
     #[error("Account ID is is not a valid CAIP-10 account ID or uses an unsupported namespace")]
-    UnrecognizedChainId,
+    Namespace,
 
-    #[error("Account ID is eip155 but does not pass ERC-55 checksum")]
-    Eip155Erc55Fail,
+    #[error("Account ID appears to be eip155 but: {0}")]
+    Eip155(#[from] Eip155Error),
 }
 
 impl TryFrom<String> for AccountId {
@@ -52,13 +53,11 @@ impl TryFrom<&str> for AccountId {
     type Error = AccountIdError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        if is_eip155_account(s) {
-            if as_erc_55(s) != s {
-                return Err(AccountIdError::Eip155Erc55Fail);
-            }
+        if s.starts_with("eip155:") {
+            is_valid_eip155_account(s)?;
             Ok(Self(Arc::from(s)))
         } else {
-            Err(AccountIdError::UnrecognizedChainId)
+            Err(AccountIdError::Namespace)
         }
     }
 }
@@ -76,11 +75,31 @@ impl<'a> Deserialize<'a> for AccountId {
     }
 }
 
-fn is_eip155_account(account_id: &str) -> bool {
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum Eip155Error {
+    #[error("does not match regex")]
+    Regex,
+
+    #[error("does not pass ERC-55 checksum")]
+    Erc55,
+}
+
+fn is_valid_eip155_account(account_id: &str) -> Result<(), Eip155Error> {
     static PATTERN_CELL: OnceCell<regex::Regex> = OnceCell::new();
-    let pattern =
-        PATTERN_CELL.get_or_init(|| regex::Regex::new(r"^eip155:\d+:0x[0-9a-fA-F]{40}$").unwrap());
-    pattern.is_match(account_id)
+    let pattern = PATTERN_CELL
+        .get_or_init(|| regex::Regex::new(r"^eip155:\d+:0x(?<address>[0-9a-fA-F]{40})$").unwrap());
+
+    if let Some(caps) = pattern.captures(account_id) {
+        let address = &caps["address"];
+        let erc55 = erc_55_checksum_encode(&address.to_ascii_lowercase()).collect::<String>();
+        if erc55 == address {
+            Ok(())
+        } else {
+            Err(Eip155Error::Erc55)
+        }
+    } else {
+        Err(Eip155Error::Regex)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -107,25 +126,8 @@ impl AccountId {
     }
 }
 
-fn as_erc_55(s: &str) -> String {
-    if s.starts_with("eip155:") {
-        let ox = "0x";
-        if let Some(ox_start) = s.find(ox) {
-            let hex_start = ox_start + ox.len();
-            s[0..hex_start]
-                .chars()
-                .chain(erc_55_checksum_encode(&s[hex_start..].to_ascii_lowercase()))
-                .collect()
-        } else {
-            // If no 0x then address is very invalid anyway. Not validating this for now, goal is just to avoid duplicates.
-            s.to_owned()
-        }
-    } else {
-        s.to_owned()
-    }
-}
-
-// Encodes a lowercase hex address with ERC-55 checksum
+// Encodes a lowercase hex address without '0x' with ERC-55 checksum
+// If a non-lowercase hex value, or a non-address is passed, the behavior is undefined
 pub fn erc_55_checksum_encode(s: &str) -> impl Iterator<Item = char> + '_ {
     let address_hash = hex::encode(Keccak256::default().chain_update(s).finalize());
     s.chars().enumerate().map(move |(i, c)| {
@@ -147,23 +149,23 @@ mod test {
 
         // Ethereum mainnet (valid/checksummed)
         let test = "eip155:1:0x22227A31dd842196A246d8f3b775998560eAa61d";
-        assert_eq!(test, as_erc_55(test));
+        assert!(is_valid_eip155_account(test).is_ok());
 
         // Ethereum mainnet (will not validate in EIP155-conformant systems)
         let test = "eip155:1:0x22227a31dd842196a246d8f3b775998560eaa61d";
-        assert_ne!(test, as_erc_55(test));
+        assert!(is_valid_eip155_account(test).is_err());
 
         // Polygon mainnet (valid/checksummed)
         let test = "eip155:137:0x0495766cD136138Fc492Dd499B8DC87A92D6685b";
-        assert_eq!(test, as_erc_55(test));
+        assert!(is_valid_eip155_account(test).is_ok());
 
         // Polygon mainnet (will not validate in EIP155-conformant systems)
         let test = "eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B";
-        assert_ne!(test, as_erc_55(test));
+        assert!(is_valid_eip155_account(test).is_err());
 
         // Not EIP155
         let junk = "jkF53jF";
-        assert_eq!(junk, as_erc_55(junk));
+        assert!(is_valid_eip155_account(junk).is_err());
     }
 
     #[test]
@@ -203,47 +205,72 @@ mod test {
     }
 
     #[test]
-    fn test_is_eip155_account() {
-        assert!(is_eip155_account(
-            "eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(is_eip155_account(
-            "eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(is_eip155_account(
-            "eip155:12:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(!is_eip155_account(
-            "eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d"
-        ));
-        assert!(!is_eip155_account(
-            "eip156:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(!is_eip155_account(
-            "eip15:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(!is_eip155_account(
-            "0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(!is_eip155_account(
-            "eip155:12:62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(!is_eip155_account(
-            "62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
-        assert!(!is_eip155_account(
-            "eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d00"
-        ));
-        assert!(!is_eip155_account(
-            "eeip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"
-        ));
+    fn test_is_valid_eip155_account() {
+        assert!(
+            is_valid_eip155_account("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_ok()
+        );
+        assert!(
+            is_valid_eip155_account("eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_ok()
+        );
+        assert!(
+            is_valid_eip155_account("eip155:12:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_ok()
+        );
+        assert!(
+            is_valid_eip155_account("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d").is_err()
+        );
+        assert!(
+            is_valid_eip155_account("eip156:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_err()
+        );
+        assert!(
+            is_valid_eip155_account("eip15:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_err()
+        );
+        assert!(is_valid_eip155_account("0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_err());
+        assert!(
+            is_valid_eip155_account("eip155:12:62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_err()
+        );
+        assert!(is_valid_eip155_account("62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_err());
+        assert!(
+            is_valid_eip155_account("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d00")
+                .is_err()
+        );
+        assert!(
+            is_valid_eip155_account("eeip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0")
+                .is_err()
+        );
     }
 
     #[test]
-    fn requires_erc_55() {
+    fn account_id_valid_namespaces() {
         assert!(AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_ok());
-        assert!(
-            AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2D0").is_err()
+        assert!(AccountId::try_from("solana:xxx").is_err());
+    }
+
+    #[test]
+    fn account_id_eip155_regex_fail() {
+        assert_eq!(
+            AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d"),
+            Err(AccountIdError::Eip155(Eip155Error::Regex))
+        );
+        assert_eq!(
+            AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d00"),
+            Err(AccountIdError::Eip155(Eip155Error::Regex))
+        );
+        assert_eq!(
+            AccountId::try_from("eip155:1:"),
+            Err(AccountIdError::Eip155(Eip155Error::Regex))
+        );
+        assert_eq!(
+            AccountId::try_from("eip155:f:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0"),
+            Err(AccountIdError::Eip155(Eip155Error::Regex))
+        );
+    }
+
+    #[test]
+    fn account_id_eip155_requires_erc_55() {
+        assert!(AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").is_ok());
+        assert_eq!(
+            AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2D0"),
+            Err(AccountIdError::Eip155(Eip155Error::Erc55))
         );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -718,58 +718,6 @@ async fn test_one_subscriber_two_projects() {
 }
 
 #[tokio::test]
-async fn test_account_case_insensitive() {
-    let (postgres, _) = get_postgres().await;
-
-    let topic = Topic::generate();
-    let project_id = ProjectId::generate();
-    let subscribe_key = generate_subscribe_key();
-    let authentication_key = generate_authentication_key();
-    let app_domain = &generate_app_domain();
-    upsert_project(
-        project_id.clone(),
-        app_domain,
-        topic,
-        &authentication_key,
-        &subscribe_key,
-        &postgres,
-        None,
-    )
-    .await
-    .unwrap();
-    let project = get_project_by_project_id(project_id.clone(), &postgres, None)
-        .await
-        .unwrap();
-
-    let (_, address) = generate_eoa();
-    let account = format_eip155_account(1, &address.to_lowercase());
-    let scope = HashSet::from([Uuid::new_v4(), Uuid::new_v4()]);
-    let notify_key = rand::Rng::gen::<[u8; 32]>(&mut rand::thread_rng());
-    let notify_topic = topic_from_key(&notify_key);
-    upsert_subscriber(
-        project.id,
-        account.clone(),
-        scope,
-        &notify_key,
-        notify_topic,
-        &postgres,
-        None,
-    )
-    .await
-    .unwrap();
-
-    let subscribers = get_subscriptions_by_account_and_maybe_app(
-        format_eip155_account(1, &address.to_uppercase().replace('X', "x")),
-        None,
-        &postgres,
-        None,
-    )
-    .await
-    .unwrap();
-    assert_eq!(subscribers.len(), 1);
-}
-
-#[tokio::test]
 async fn test_get_subscriber_accounts_by_project_id() {
     let (postgres, _) = get_postgres().await;
 
@@ -6513,35 +6461,6 @@ pub async fn test_same_account() {
         true,
         &AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").unwrap(),
         &AccountId::try_from("eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").unwrap(),
-        &postgres,
-    )
-    .await;
-    test(
-        true,
-        &AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").unwrap(),
-        &AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2D0").unwrap(),
-        &postgres,
-    )
-    .await;
-    test(
-        true,
-        &AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2d0").unwrap(),
-        &AccountId::try_from("eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2D0").unwrap(),
-        &postgres,
-    )
-    .await;
-
-    test(
-        false,
-        &AccountId::try_from("eip155:1:0x62639418051006514eD5Bb5B20aa7aAD642cC2e0").unwrap(),
-        &AccountId::try_from("eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2D0").unwrap(),
-        &postgres,
-    )
-    .await;
-    test(
-        false,
-        &AccountId::try_from("eip155:1:0x52639418051006514eD5Bb5B20aa7aAD642cC2D0").unwrap(),
-        &AccountId::try_from("eip155:2:0x62639418051006514eD5Bb5B20aa7aAD642cC2D0").unwrap(),
         &postgres,
     )
     .await;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -6,7 +6,7 @@ use {
     notify_server::{
         auth::{AuthError, DidWeb, GetSharedClaims, SharedClaims},
         error::NotifyServerError,
-        model::types::AccountId,
+        model::types::{erc_55_checksum_encode, AccountId},
         notify_message::NotifyMessage,
         relay_client_helpers::create_http_client,
     },
@@ -237,7 +237,10 @@ pub fn generate_eoa() -> (SigningKey, String) {
                 .as_bytes()[1..],
         )
         .finalize()[12..];
-    let address = format!("0x{}", hex::encode(address));
+    let address = format!(
+        "0x{}",
+        erc_55_checksum_encode(&hex::encode(address)).collect::<String>()
+    );
     (account_signing_key, address)
 }
 


### PR DESCRIPTION
# Description

Followup to #364. CAIP-10 [requires the use of ERC-55](https://github.com/ChainAgnostic/namespaces/blob/main/eip155/caip10.md#syntax), and until now we have been permissive about this and normalized to ERC-55 internally. However, we should follow the spec and require ERC-55 now so people don't get lazy in the future.

This PR updates the logic to require ERC-55 to construct an `AccountId`. If this fails validation, an error will be returned to the appropriate party.

Logs show that the only non-compliance with ERC-55 is in the use of the `/notify` endpoint from 1 obscure project with 0 subscribers, and 1 client that appeared today. I decided not to build backwards-compatibility for these 2 entities.

Also I manually checked that all existing database rows are all eip155 accounts and are ERC-55 compliant.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
