### PR TITLE
fix: attribute Keys Server 404 as client error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,9 +93,9 @@ wiremock = "0.5.19"
 itertools = "0.11.0"
 sha3 = "0.10.8"
 validator = { version = "0.16.1", features = ["derive"] }
+k256 = "0.13.1"
 
 [dev-dependencies]
-k256 = "0.13.1"
 test-context = "0.1"
 
 [build-dependencies]

--- a/src/model/types/account_id/mod.rs
+++ b/src/model/types/account_id/mod.rs
@@ -5,8 +5,8 @@ use {
     std::sync::Arc,
 };
 
-mod caip10;
-mod eip155;
+pub mod caip10;
+pub mod eip155;
 pub mod erc55;
 
 #[derive(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -113,8 +113,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             &state.provider,
             state.metrics.as_ref(),
         )
-        .await
-        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+        .await?;
 
         // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -112,8 +112,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             &state.provider,
             state.metrics.as_ref(),
         )
-        .await
-        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+        .await?;
 
         // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -133,8 +133,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             &state.provider,
             state.metrics.as_ref(),
         )
-        .await
-        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+        .await?;
 
         // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -111,8 +111,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             &state.provider,
             state.metrics.as_ref(),
         )
-        .await
-        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+        .await?;
 
         // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -104,8 +104,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             &state.provider,
             state.metrics.as_ref(),
         )
-        .await
-        .map_err(RelayMessageServerError::NotifyServerError)? // TODO change to client error?
+        .await?
 
         // TODO verify `sub_auth.aud` matches `notify-server.identity_keypair`
 

--- a/tests/deployment.rs
+++ b/tests/deployment.rs
@@ -1,15 +1,19 @@
 use {
     crate::utils::{
-        assert_successful_response, generate_account, generate_identity_key,
+        assert_successful_response,
         http_api::subscribe_topic,
         notify_relay_api::{
             accept_notify_message, accept_watch_subscriptions_changed, subscribe,
             watch_subscriptions,
         },
-        sign_cacao, unregister_identity_key, IdentityKeyDetails, RelayClient,
+        unregister_identity_key, RelayClient,
     },
     notify_server::{
-        auth::{CacaoValue, DidWeb, STATEMENT_THIS_DOMAIN},
+        auth::{
+            test_utils::{generate_identity_key, sign_cacao, IdentityKeyDetails},
+            CacaoValue, DidWeb, STATEMENT_THIS_DOMAIN,
+        },
+        model::types::eip155::test_utils::generate_account,
         rpc::decode_key,
         services::public_http_server::handlers::notify_v0::NotifyBody,
         types::Notification,

--- a/tests/utils/notify_relay_api.rs
+++ b/tests/utils/notify_relay_api.rs
@@ -2,7 +2,7 @@ use {
     super::{
         encode_auth,
         relay_api::{publish_jwt_message, TopicEncrptionScheme, TopicEncryptionSchemeAsymetric},
-        IdentityKeyDetails, RelayClient,
+        RelayClient,
     },
     crate::utils::{
         http_api::get_notify_did_json,
@@ -11,10 +11,10 @@ use {
     },
     notify_server::{
         auth::{
-            from_jwt, DidWeb, NotifyServerSubscription, SubscriptionRequestAuth,
-            SubscriptionResponseAuth, WatchSubscriptionsChangedRequestAuth,
-            WatchSubscriptionsChangedResponseAuth, WatchSubscriptionsRequestAuth,
-            WatchSubscriptionsResponseAuth,
+            from_jwt, test_utils::IdentityKeyDetails, DidWeb, NotifyServerSubscription,
+            SubscriptionRequestAuth, SubscriptionResponseAuth,
+            WatchSubscriptionsChangedRequestAuth, WatchSubscriptionsChangedResponseAuth,
+            WatchSubscriptionsRequestAuth, WatchSubscriptionsResponseAuth,
         },
         model::types::AccountId,
         notify_message::NotifyMessage,

--- a/tests/utils/relay_api.rs
+++ b/tests/utils/relay_api.rs
@@ -1,10 +1,10 @@
 use {
-    super::{IdentityKeyDetails, RelayClient},
+    super::RelayClient,
     chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit},
     chrono::{DateTime, Utc},
     data_encoding::BASE64,
     notify_server::{
-        auth::{add_ttl, from_jwt, GetSharedClaims, SharedClaims},
+        auth::{add_ttl, from_jwt, test_utils::IdentityKeyDetails, GetSharedClaims, SharedClaims},
         rpc::{derive_key, JsonRpcResponse, ResponseAuth},
         types::{Envelope, EnvelopeType0, EnvelopeType1},
         utils::topic_from_key,


### PR DESCRIPTION
# Description

Handles the Keys Server 404 error as a client error. Also refactors all the identity verification error handling logic to be an internal vs client error.

Introduced shared `test_utils` as a regular module as both integration tests (which are not `#[cfg(test)]`) and unit tests use it.

Resolves #327 

## How Has This Been Tested?

New test case

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
