### PR TITLE
fix: unknown topic client error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -101,9 +101,6 @@ pub enum NotifyServerError {
     #[error("No project found associated with app_domain {0}")]
     NoProjectDataForAppDomain(Arc<str>),
 
-    #[error("No client found associated with topic {0}")]
-    NoClientDataForTopic(Topic),
-
     #[error("No project found associated with project ID {0}")]
     NoProjectDataForProjectId(ProjectId),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,21 +2,19 @@ use {
     crate::{
         analytics::AnalyticsInitError,
         auth,
-        model::types::AccountId,
         rate_limit::{InternalRateLimitError, RateLimitExceeded},
     },
     axum::{response::IntoResponse, Json},
     chacha20poly1305::aead,
-    data_encoding::DecodeError,
     hyper::StatusCode,
     relay_client::error::ClientError,
     relay_rpc::{
         auth::{did::DidError, ed25519_dalek::ed25519},
-        domain::{ClientIdDecodingError, ProjectId, Topic},
+        domain::Topic,
         rpc::{PublishError, SubscriptionError, WatchError},
     },
     serde_json::json,
-    std::{array::TryFromSliceError, string::FromUtf8Error, sync::Arc},
+    std::{array::TryFromSliceError, sync::Arc},
     thiserror::Error,
     tracing::{error, info, warn},
 };
@@ -31,15 +29,6 @@ pub enum NotifyServerError {
 
     #[error("Failed to load configuration from environment {0}")]
     EnvConfiguration(#[from] envy::Error),
-
-    #[error("Invalid event for webhook")]
-    InvalidEvent,
-
-    #[error("The provided url has invalid scheme")]
-    InvalidScheme,
-
-    #[error("The Relay client has stopped working")]
-    RelayClientStopped,
 
     #[error("Invalid account")]
     InvalidAccount,
@@ -63,22 +52,10 @@ pub enum NotifyServerError {
     Uuid(#[from] uuid::Error),
 
     #[error(transparent)]
-    Prometheus(#[from] prometheus_core::Error),
-
-    #[error(transparent)]
     SerdeJson(#[from] serde_json::error::Error),
 
     #[error(transparent)]
-    Broadcast(#[from] tokio::sync::broadcast::error::TryRecvError),
-
-    #[error(transparent)]
-    FromUtf8Error(#[from] FromUtf8Error),
-
-    #[error(transparent)]
-    TokioTimeElapsed(#[from] tokio::time::error::Elapsed),
-
-    #[error(transparent)]
-    Base64Decode(#[from] base64::DecodeError),
+    TokioTimeElapsed(tokio::time::error::Elapsed),
 
     #[error(transparent)]
     RelayClientError(#[from] ClientError),
@@ -92,29 +69,11 @@ pub enum NotifyServerError {
     #[error(transparent)]
     RelayWatchError(#[from] relay_client::error::Error<WatchError>),
 
-    #[error(transparent)]
-    TryRecvError(#[from] tokio::sync::mpsc::error::TryRecvError),
-
     #[error("No project found associated with topic {0}")]
     NoProjectDataForTopic(Topic),
 
     #[error("No project found associated with app_domain {0}")]
     NoProjectDataForAppDomain(Arc<str>),
-
-    #[error("No project found associated with project ID {0}")]
-    NoProjectDataForProjectId(ProjectId),
-
-    #[error("No client found associated with project ID {0} and account {1}")]
-    NoClientDataForProjectIdAndAccount(ProjectId, AccountId),
-
-    #[error("Tried to interact with channel that's already closed")]
-    ChannelClosed,
-
-    #[error(transparent)]
-    DecodeError(#[from] DecodeError),
-
-    #[error("Missing {0}")]
-    SubscriptionAuthError(String),
 
     // TODO move this error somewhere else more specific
     #[error("TryFromSliceError: {0}")]
@@ -127,32 +86,14 @@ pub enum NotifyServerError {
     #[error("Invalid key length: {0}")]
     HkdfInvalidLength(hkdf::InvalidLength),
 
-    #[error("Failed to get value from json")]
-    JsonGetError,
-
     #[error("Cryptography failure: {0}")]
     EncryptionError(aead::Error),
-
-    #[error(transparent)]
-    SystemTimeError(#[from] std::time::SystemTimeError),
 
     #[error("Failed to parse the keypair seed")]
     InvalidKeypairSeed,
 
-    #[error("GeoIpReader Error: {0}")]
-    GeoIpReader(String),
-
-    #[error("BatchCollector Error: {0}")]
-    BatchCollector(String),
-
     #[error(transparent)]
     JwtVerificationError(#[from] auth::AuthError),
-
-    #[error(transparent)]
-    ClientIdDecodingError(#[from] ClientIdDecodingError),
-
-    #[error(transparent)]
-    ChronoParse(#[from] chrono::ParseError),
 
     #[error(transparent)]
     AnalyticsInitError(#[from] AnalyticsInitError),
@@ -162,9 +103,6 @@ pub enum NotifyServerError {
 
     #[error(transparent)]
     InvalidHeaderValue(#[from] hyper::header::InvalidHeaderValue),
-
-    #[error(transparent)]
-    ToStrError(#[from] hyper::header::ToStrError),
 
     #[error(transparent)]
     EdDalek(#[from] ed25519::Error),

--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -16,13 +16,13 @@ pub enum RelayMessageClientError {
     #[error("Received 4010 on wrong topic: {0}")]
     WrongNotifyWatchSubscriptionsTopic(Topic),
 
-    #[error("Received 4008 on unrecognied topic: {0}")]
+    #[error("Received 4008 on unrecognized topic: {0}")]
     WrongNotifyUpdateTopic(Topic),
 
-    #[error("Received 4004 on unrecognied topic: {0}")]
+    #[error("Received 4004 on unrecognized topic: {0}")]
     WrongNotifyDeleteTopic(Topic),
 
-    #[error("Received 4014 on unrecognied topic: {0}")]
+    #[error("Received 4014 on unrecognized topic: {0}")]
     WrongNotifyGetNotificationsTopic(Topic),
 
     #[error("Decode message: {0}")]

--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -13,8 +13,17 @@ use {
 
 #[derive(Debug, thiserror::Error)]
 pub enum RelayMessageClientError {
-    #[error("Received wc_notifyWatchSubscriptions (4010) on wrong topic: {0}")]
+    #[error("Received 4010 on wrong topic: {0}")]
     WrongNotifyWatchSubscriptionsTopic(Topic),
+
+    #[error("Received 4008 on unrecognied topic: {0}")]
+    WrongNotifyUpdateTopic(Topic),
+
+    #[error("Received 4004 on unrecognied topic: {0}")]
+    WrongNotifyDeleteTopic(Topic),
+
+    #[error("Received 4014 on unrecognied topic: {0}")]
+    WrongNotifyGetNotificationsTopic(Topic),
 
     #[error("Decode message: {0}")]
     DecodeMessage(#[from] base64::DecodeError),

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -50,10 +50,13 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         get_subscriber_by_topic(topic.clone(), &state.postgres, state.metrics.as_ref())
             .await
             .map_err(|e| match e {
-                sqlx::Error::RowNotFound => NotifyServerError::NoClientDataForTopic(topic.clone()),
-                e => e.into(),
-            })
-            .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+                sqlx::Error::RowNotFound => RelayMessageError::Client(
+                    RelayMessageClientError::WrongNotifyGetNotificationsTopic(topic.clone()),
+                ),
+                e => {
+                    RelayMessageError::Server(RelayMessageServerError::NotifyServerError(e.into()))
+                }
+            })?;
     let project = get_project_by_id(subscriber.project, &state.postgres, state.metrics.as_ref())
         .await
         .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -51,10 +51,13 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         get_subscriber_by_topic(topic.clone(), &state.postgres, state.metrics.as_ref())
             .await
             .map_err(|e| match e {
-                sqlx::Error::RowNotFound => NotifyServerError::NoClientDataForTopic(topic.clone()),
-                e => e.into(),
-            })
-            .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+                sqlx::Error::RowNotFound => RelayMessageError::Client(
+                    RelayMessageClientError::WrongNotifyUpdateTopic(topic.clone()),
+                ),
+                e => {
+                    RelayMessageError::Server(RelayMessageServerError::NotifyServerError(e.into()))
+                }
+            })?;
     let project = get_project_by_id(subscriber.project, &state.postgres, state.metrics.as_ref())
         .await
         .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?


### PR DESCRIPTION
# Description

Attributes unknown topic errors as client errors. Also removes a lot of unused error variants from `NotifyServerError`

Resolves #373

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
