### PR TITLE
fix: log relay message

### DIFF
--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -106,6 +106,7 @@ pub async fn handler(
 
     let claims = WatchEventClaims::try_from_str(event)
         .map_err(|e| Error::ClientError(ClientError::ParseWatchEvent(e)))?;
+    info!("Received watch event with message ID: {}", claims.evt.message_id);
 
     claims
         .verify_basic(&HashSet::from([state.config.notify_url.to_string()]), None)

--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -106,7 +106,10 @@ pub async fn handler(
 
     let claims = WatchEventClaims::try_from_str(event)
         .map_err(|e| Error::ClientError(ClientError::ParseWatchEvent(e)))?;
-    info!("Received watch event with message ID: {}", claims.evt.message_id);
+    info!(
+        "Received watch event with message ID: {}",
+        claims.evt.message_id
+    );
 
     claims
         .verify_basic(&HashSet::from([state.config.notify_url.to_string()]), None)


### PR DESCRIPTION
# Description

Paired with https://github.com/WalletConnect/rs-relay/pull/1448 this debugs long delays in delivering webhooks.

[Slack conversation](https://walletconnect.slack.com/archives/C044SKFKELR/p1708610471719339)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
