### PR TITLE
fix: reduce test timeout

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -45,7 +45,7 @@ pub mod http_api;
 pub mod notify_relay_api;
 pub mod relay_api;
 
-pub const RELAY_MESSAGE_DELIVERY_TIMEOUT: Duration = Duration::from_secs(30);
+pub const RELAY_MESSAGE_DELIVERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub const JWT_LEEWAY: i64 = 30;
 


### PR DESCRIPTION
# Description

Timeout doesn't need to be this long, and reducing it allows us to catch regressions in performance

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
