### PR TITLE
fix: increase channel size

### DIFF
--- a/src/services/relay_mailbox_clearing_service.rs
+++ b/src/services/relay_mailbox_clearing_service.rs
@@ -12,11 +12,14 @@ use {
 const BATCH_SIZE: usize = 500;
 pub const BATCH_TIMEOUT: Duration = Duration::from_secs(5);
 
+// The size of the queue of batches to send to the relay
+const BATCHES_QUEUE_SIZE: usize = 10;
+
 pub async fn start(
     relay_client: Arc<Client>,
     batch_receive_rx: Receiver<Receipt>,
 ) -> Result<(), Infallible> {
-    let (output_tx, mut output_rx) = tokio::sync::mpsc::channel(1);
+    let (output_tx, mut output_rx) = tokio::sync::mpsc::channel(BATCHES_QUEUE_SIZE);
     let relay_handler = async {
         while let Some(receipts) = output_rx.recv().await {
             if let Err(e) = relay_client.batch_receive(receipts).await {


### PR DESCRIPTION
# Description

Calling `batch_receive()` takes some time, and at high request throughputs (if `req/s / 500 > call time OR call time > batch_timeout`) this channel can block and increase request latency. Doesn't seem like an issue now (we have low req/s), and we don't know for sure because we don't have metrics on this request (yet). But increasing it preemptively as memory is not a problem.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
