### PR TITLE
fix: log whu, sub, aud, and JSON-RPC info

### DIFF
--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -80,9 +80,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifyDelete, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {:?}", msg.id);
-    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {:?}", msg.method); // TODO verify this
+    info!("msg.id: {}", msg.id);
+    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionDeleteRequestAuth>(&msg.params.delete_auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -80,6 +80,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifyDelete, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    info!("msg.id: {:?}", msg.id);
+    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {:?}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionDeleteRequestAuth>(&msg.params.delete_auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -79,9 +79,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<AuthMessage, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {:?}", msg.id);
-    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {:?}", msg.method); // TODO verify this
+    info!("msg.id: {}", msg.id);
+    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionGetNotificationsRequestAuth>(&msg.params.auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -79,6 +79,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<AuthMessage, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    info!("msg.id: {:?}", msg.id);
+    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {:?}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionGetNotificationsRequestAuth>(&msg.params.auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -97,9 +97,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifySubscribe, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {:?}", msg.id);
-    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {:?}", msg.method); // TODO verify this
+    info!("msg.id: {}", msg.id);
+    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionRequestAuth>(&msg.params.subscription_auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -97,6 +97,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifySubscribe, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    info!("msg.id: {:?}", msg.id);
+    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {:?}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionRequestAuth>(&msg.params.subscription_auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -78,9 +78,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifyUpdate, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {:?}", msg.id);
-    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {:?}", msg.method); // TODO verify this
+    info!("msg.id: {}", msg.id);
+    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionUpdateRequestAuth>(&msg.params.update_auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -78,6 +78,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifyUpdate, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    info!("msg.id: {:?}", msg.id);
+    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {:?}", msg.method); // TODO verify this
 
     let request_auth = from_jwt::<SubscriptionUpdateRequestAuth>(&msg.params.update_auth)
         .map_err(RelayMessageClientError::JwtError)?;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -74,9 +74,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifyWatchSubscriptions, _>(envelope, &response_sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {:?}", msg.id);
-    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {:?}", msg.method); // TODO verify this
+    info!("msg.id: {}", msg.id);
+    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {}", msg.method); // TODO verify this
 
     let id = msg.id;
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -74,6 +74,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let msg = decrypt_message::<NotifyWatchSubscriptions, _>(envelope, &response_sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    info!("msg.id: {:?}", msg.id);
+    info!("msg.jsonrpc: {:?}", msg.jsonrpc); // TODO verify this
+    info!("msg.method: {:?}", msg.method); // TODO verify this
 
     let id = msg.id;
 

--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -110,6 +110,9 @@ pub async fn handler(
         "Received watch event with message ID: {}",
         claims.evt.message_id
     );
+    info!("whu: {}", claims.whu);
+    info!("sub: {}", claims.basic.sub);
+    info!("aud: {}", claims.basic.aud);
 
     claims
         .verify_basic(&HashSet::from([state.config.notify_url.to_string()]), None)

--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -110,9 +110,6 @@ pub async fn handler(
         "Received watch event with message ID: {}",
         claims.evt.message_id
     );
-    info!("whu: {}", claims.whu);
-    info!("sub: {}", claims.basic.sub);
-    info!("aud: {}", claims.basic.aud);
 
     claims
         .verify_basic(&HashSet::from([state.config.notify_url.to_string()]), None)
@@ -123,6 +120,7 @@ pub async fn handler(
     }
 
     // TODO check sub
+    info!("sub: {}", claims.basic.sub);
 
     let event = claims.evt;
 
@@ -134,6 +132,16 @@ pub async fn handler(
         })
         .await
         .expect("Batch receive channel should not be closed");
+
+    // Check these after the mailbox cleaner because these
+    // messages would actually be in the mailbox becuase
+    // the client ID (sub) matches, meaning we are the one
+    // that subscribed. However, aud and whu are not valid,
+    // that's a relay error. We should still clear the mailbox
+    // TODO check sub
+    info!("aud: {}", claims.basic.aud);
+    // TODO check whu
+    info!("whu: {}", claims.whu);
 
     let incoming_message = RelayIncomingMessage {
         topic: event.topic,
@@ -149,7 +157,6 @@ pub async fn handler(
     if claims.typ != WatchType::Subscriber {
         return Err(Error::ClientError(ClientError::WrongWatchType(claims.typ)));
     }
-    // TODO check whu
 
     if event.status != WatchStatus::Queued {
         return Err(Error::ClientError(ClientError::WrongWatchStatus(


### PR DESCRIPTION
# Description

Logs this info for debugging. Also changes the ordering to more align with how these values will be validated in the future.

Also logs JSON-RPC info as oftentimes debuggers give me JSON-RPC ID instead of message ID.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
