### PR TITLE
fix: downscale

### DIFF
--- a/terraform/ecs/cluster_autoscaling.tf
+++ b/terraform/ecs/cluster_autoscaling.tf
@@ -1,5 +1,9 @@
+locals {
+  autoscaling_min_capacity = module.this.stage == "prod" ? var.autoscaling_min_capacity : 1
+}
+
 resource "aws_appautoscaling_target" "ecs_target" {
-  min_capacity       = var.autoscaling_min_capacity
+  min_capacity       = local.autoscaling_min_capacity
   max_capacity       = var.autoscaling_max_capacity
   resource_id        = "service/${aws_ecs_cluster.app_cluster.name}/${aws_ecs_service.app_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"

--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -44,7 +44,7 @@ module "db_cluster" {
   cloudwatch_log_group_retention_in_days = var.cloudwatch_retention_in_days
 
   serverlessv2_scaling_configuration = {
-    min_capacity = var.min_capacity
+    min_capacity = module.this.stage == "prod" ? var.min_capacity : 0.5
     max_capacity = var.max_capacity
   }
 }

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -35,8 +35,8 @@ module "ecs" {
   ecr_repository_url        = local.ecr_repository_url
   image_version             = var.image_version
   task_execution_role_name  = aws_iam_role.application_role.name
-  task_cpu                  = 8064  # 8192 - 128
-  task_memory               = 16256 # 16384-128
+  task_cpu                  = 4096
+  task_memory               = 8192
   autoscaling_desired_count = var.app_autoscaling_desired_count
   autoscaling_min_capacity  = var.app_autoscaling_min_capacity
   autoscaling_max_capacity  = var.app_autoscaling_max_capacity


### PR DESCRIPTION
# Description

- Downscales prod ECS task CPU and memory by half. CPU and memory has been idling around <5% except for spikes up to around 30%. Halving this to reduce cost and lean into horizontal scaling soon.
- Downscales staging deployment by setting min capacities to their minimum for non-prod deployments:
  - Minimum CPU + memory as possible
  - Minimum RDS ACUs as possible
  - Single replica minimum (when we enable HA + HS we'll have 2 as the minimum here)
- Refactor task CPU calculation to make task memory be the main app + otel sidecar size. Prev: needed to do math to see which size to use.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
