### PR TITLE
fix: enable autoscaling

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -1,6 +1,8 @@
 locals {
   image = "${var.ecr_repository_url}:${var.image_version}"
 
+  desired_count = module.this.stage == "prod" ? var.autoscaling_desired_count : 1
+
   task_cpu    = module.this.stage == "prod" ? var.task_cpu : 256
   task_memory = module.this.stage == "prod" ? var.task_memory : 512
 
@@ -175,7 +177,7 @@ resource "aws_ecs_service" "app_service" {
   cluster         = aws_ecs_cluster.app_cluster.id
   task_definition = aws_ecs_task_definition.app_task.arn
   launch_type     = "FARGATE"
-  desired_count   = var.autoscaling_desired_count
+  desired_count   = local.desired_count
   propagate_tags  = "TASK_DEFINITION"
 
   # Wait for the service deployment to succeed

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -29,19 +29,19 @@ variable "task_memory" {
 variable "autoscaling_desired_count" {
   description = "Minimum number of instances in the autoscaling group"
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "autoscaling_min_capacity" {
   description = "Minimum number of instances in the autoscaling group"
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "autoscaling_max_capacity" {
   description = "Maximum number of instances in the autoscaling group"
   type        = number
-  default     = 1
+  default     = 8
 }
 
 variable "cloudwatch_logs_key_arn" {


### PR DESCRIPTION
# Description

Enables autoscaling to have horizontal scalability and sets a min capacity of 2 to have high availability.

Also fixes that desired count wasn't being set to 1 in non-prod.

Blocked by #388 ([explanation](https://github.com/WalletConnect/notify-server/issues/362#issuecomment-1965422922))

Resolves #362 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
