### PR TITLE
fix: limit subscription watcher count

### DIFF
--- a/migrations/20240227222554_index_subscription_watcher_account.sql
+++ b/migrations/20240227222554_index_subscription_watcher_account.sql
@@ -1,0 +1,1 @@
+CREATE INDEX subscription_watcher_address ON subscription_watcher (get_address_lower(account));

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,7 +120,7 @@ pub enum NotifyServerError {
     AccountNotAuthorized,
 
     #[error("sqlx error: {0}")]
-    SqlxError(#[from] sqlx::error::Error),
+    Sqlx(#[from] sqlx::error::Error),
 
     #[error("sqlx migration error: {0}")]
     SqlxMigrationError(#[from] sqlx::migrate::MigrateError),

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -707,10 +707,6 @@ pub async fn upsert_subscription_watcher(
     postgres: &PgPool,
     metrics: Option<&Metrics>,
 ) -> Result<(), UpsertSubscriptionWatcherError> {
-    #[derive(Debug, FromRow)]
-    struct Result {
-        // We don't need any fields
-    }
     let query = "
         INSERT INTO subscription_watcher (
             account,
@@ -739,7 +735,7 @@ pub async fn upsert_subscription_watcher(
     sqlx::query::<Postgres>("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE") // TODO serialization errors not handled
         .execute(&mut *txn)
         .await?;
-    let result = sqlx::query_as::<Postgres, Result>(query)
+    let result = sqlx::query_as::<Postgres, ()>(query)
         .bind(account.as_ref())
         .bind(project)
         .bind(did_key)

--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -16,6 +16,9 @@ pub enum RelayMessageClientError {
     #[error("Received 4010 on wrong topic: {0}")]
     WrongNotifyWatchSubscriptionsTopic(Topic),
 
+    #[error("Subscription watcher limit reached")]
+    SubscriptionWatcherLimitReached,
+
     #[error("Received 4008 on unrecognized topic: {0}")]
     WrongNotifyUpdateTopic(Topic),
 


### PR DESCRIPTION
# Description

Adds a limit to the number of subscription watchers that can be registered at once. It limits to 25 watchers per project value, which means that each app_domain can have up to 25 watchers, and for watchers without a project specified can also have a maximum of 25 (e.g. app.web3inbox.com, wallets, mis-configured apps).

Looking at our data, it seems like there is no more than 13 of these at once. But more than 2-3 seems very odd in the first place.

For context: watchers also expire after 1 day.

## How Has This Been Tested?

New test case.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
