### PR TITLE
fix: publish response and subscription watcher updates in parallel

### DIFF
--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -190,7 +190,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .await
     .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
 
-    {
+    let response_fut = async {
         let now = Utc::now();
         let response_message = SubscriptionDeleteResponseAuth {
             shared_claims: SharedClaims {
@@ -231,19 +231,22 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             state.metrics.as_ref(),
         )
         .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
-    }
+        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into())) // TODO change to client error?
+    };
 
-    send_to_subscription_watchers(
-        watchers_with_subscriptions,
-        &state.notify_keys.authentication_secret,
-        &state.notify_keys.authentication_client_id,
-        &state.relay_client,
-        state.metrics.as_ref(),
-    )
-    .await
-    .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    let watcher_fut = async {
+        send_to_subscription_watchers(
+            watchers_with_subscriptions,
+            &state.notify_keys.authentication_secret,
+            &state.notify_keys.authentication_client_id,
+            &state.relay_client,
+            state.metrics.as_ref(),
+        )
+        .await
+        .map_err(RelayMessageServerError::NotifyServerError) // TODO change to client error?
+    };
 
+    tokio::try_join!(response_fut, watcher_fut)?;
     Ok(())
 }
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -272,7 +272,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .await
     .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
 
-    {
+    let response_fut = async {
         let now = Utc::now();
         let response_message = SubscriptionResponseAuth {
             shared_claims: SharedClaims {
@@ -316,18 +316,22 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         .await
         .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
         info!("Finished publishing subscribe response");
-    }
+        Ok(())
+    };
 
-    send_to_subscription_watchers(
-        watchers_with_subscriptions,
-        &state.notify_keys.authentication_secret,
-        &state.notify_keys.authentication_client_id,
-        &state.relay_client,
-        state.metrics.as_ref(),
-    )
-    .await
-    .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    let watcher_fut = async {
+        send_to_subscription_watchers(
+            watchers_with_subscriptions,
+            &state.notify_keys.authentication_secret,
+            &state.notify_keys.authentication_client_id,
+            &state.relay_client,
+            state.metrics.as_ref(),
+        )
+        .await
+        .map_err(RelayMessageServerError::NotifyServerError) // TODO change to client error?
+    };
 
+    tokio::try_join!(response_fut, watcher_fut)?;
     Ok(())
 }
 


### PR DESCRIPTION
# Description

Performs the response publish and the watcher publishes all in parallel (with a concurrency limit of 11). The goal being to get watch updates to watchers faster, and to reduce our overall latency metric for processing incoming relay messages.

Resolves #266 

## How Has This Been Tested?

Existing tests. Latency metrics will be improved but latency is not tested automatically until we have a latency canary.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
