### PR TITLE
fix: increase RDS max capacity to handle spikes in message sending

### DIFF
--- a/terraform/postgres/variables.tf
+++ b/terraform/postgres/variables.tf
@@ -37,7 +37,7 @@ variable "min_capacity" {
 variable "max_capacity" {
   description = "The maximum capacity for the Aurora cluster (in Aurora Capacity Units)"
   type        = number
-  default     = 10
+  default     = 20
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Fixes alarms that we are using more than half of our RDS CPU. This is caused by an [inefficiency in the send notification queue](https://github.com/WalletConnect/notify-server/issues/320). This will be resolved, but we can work around the alarms for now by increasing the ACUs.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
