### PR TITLE
fix: notify message should use did:web

### DIFF
--- a/src/notify_message.rs
+++ b/src/notify_message.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        auth::{add_ttl, sign_jwt},
+        auth::{add_ttl, sign_jwt, DidWeb},
         error::NotifyServerError,
         model::types::AccountId,
         spec::{NOTIFY_MESSAGE_ACT, NOTIFY_MESSAGE_TTL},
@@ -16,7 +16,7 @@ use {
 pub struct ProjectSigningDetails {
     pub decoded_client_id: DecodedClientId,
     pub private_key: SigningKey,
-    pub app: Arc<str>,
+    pub app: DidWeb,
 }
 
 pub fn sign_message(
@@ -51,7 +51,7 @@ pub struct NotifyMessage {
     pub iss: String,               // dapps identity key
     pub act: String,               // action intent (must be "notify_message")
     pub sub: String,               // did:pkh of blockchain account
-    pub app: Arc<str>,             // dapp domain url
+    pub app: DidWeb,               // dapp domain url
     pub msg: Arc<JwtNotification>, // message
 }
 

--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -2,6 +2,7 @@ use {
     self::helpers::{pick_subscriber_notification_for_processing, NotificationToProcess},
     crate::{
         analytics::{subscriber_notification::SubscriberNotificationParams, NotifyAnalytics},
+        auth::DidWeb,
         error::NotifyServerError,
         metrics::Metrics,
         notify_message::{sign_message, JwtNotification, ProjectSigningDetails},
@@ -288,7 +289,7 @@ async fn process_notification(
         ProjectSigningDetails {
             decoded_client_id,
             private_key,
-            app: notification.project_app_domain.clone().into(),
+            app: DidWeb::from_domain(notification.project_app_domain),
         }
     };
 

--- a/terraform/postgres/README.md
+++ b/terraform/postgres/README.md
@@ -35,7 +35,7 @@ This module creates a Postgres RDS cluster with IAM authentication.
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The name of the default database in the cluster |  <pre lang="json">string</pre> |  <pre lang="json">"postgres"</pre> |  no |
 | <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | The CIDR blocks to allow ingress from |  <pre lang="json">list(string)</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_instances"></a> [instances](#input\_instances) | The number of database instances to create |  <pre lang="json">number</pre> |  <pre lang="json">1</pre> |  no |
-| <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | The maximum capacity for the Aurora cluster (in Aurora Capacity Units) |  <pre lang="json">number</pre> |  <pre lang="json">10</pre> |  no |
+| <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | The maximum capacity for the Aurora cluster (in Aurora Capacity Units) |  <pre lang="json">number</pre> |  <pre lang="json">20</pre> |  no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | The minimum capacity for the Aurora cluster (in Aurora Capacity Units) |  <pre lang="json">number</pre> |  <pre lang="json">2</pre> |  no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The IDs of the subnets to deploy to |  <pre lang="json">list(string)</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to create the security group in |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |

--- a/tests/utils/notify_relay_api.rs
+++ b/tests/utils/notify_relay_api.rs
@@ -361,7 +361,7 @@ pub async fn accept_notify_message(
     assert_eq!(claims.sub, account.to_did_pkh());
     assert!(claims.iat < chrono::Utc::now().timestamp() + JWT_LEEWAY); // TODO remove leeway
     assert!(claims.exp > chrono::Utc::now().timestamp() - JWT_LEEWAY); // TODO remove leeway
-    assert_eq!(claims.app.as_ref(), app_domain.domain()); // bug: https://github.com/WalletConnect/notify-server/issues/251
+    assert_eq!(&claims.app, app_domain);
     assert_eq!(claims.act, NOTIFY_MESSAGE_ACT);
     assert!(is_same_address(
         &AccountId::from_did_pkh(&claims.sub).unwrap(),


### PR DESCRIPTION
# Description

Fixes that notify message `app` field didn't use a `did:web` as per [the specs](https://specs.walletconnect.com/2.0/specs/clients/notify/authentication#wc_notifymessage-request).

As per [this discussion](https://walletconnect.slack.com/archives/C044SKFKELR/p1703388140774189) no clients depend on the current behavior, so while this is a breaking change it should not affect anything.

Resolves #251 

## How Has This Been Tested?

Updated tests

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
