### PR TITLE
fix: error responses

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -69,20 +69,28 @@ impl<T> JsonRpcResponse<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct JsonRpcResponseError<T> {
+pub struct JsonRpcResponseError {
     pub id: MessageId,
     pub jsonrpc: Arc<str>,
-    pub error: T, // TODO use standard structure
+    pub error: JsonRpcError,
 }
 
-impl<T> JsonRpcResponseError<T> {
-    pub fn new(id: MessageId, error: T) -> Self {
+impl JsonRpcResponseError {
+    pub fn new(id: MessageId, error: JsonRpcError) -> Self {
         Self {
             id,
             jsonrpc: JSON_RPC_VERSION.clone(),
             error,
         }
     }
+}
+
+// https://www.jsonrpc.org/specification#error_object
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i16,
+    pub message: String,
+    // pub data: Value,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -42,7 +42,7 @@ pub struct JsonRpcRequest<T> {
 
 impl<T> JsonRpcRequest<T> {
     pub fn new(method: &str, params: T) -> Self {
-        JsonRpcRequest {
+        Self {
             id: MESSAGE_ID_GENERATOR.next(),
             jsonrpc: JSON_RPC_VERSION.clone(),
             method: method.to_owned(),
@@ -60,10 +60,27 @@ pub struct JsonRpcResponse<T> {
 
 impl<T> JsonRpcResponse<T> {
     pub fn new(id: MessageId, result: T) -> Self {
-        JsonRpcResponse {
+        Self {
             id,
             jsonrpc: JSON_RPC_VERSION.clone(),
             result,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JsonRpcResponseError<T> {
+    pub id: MessageId,
+    pub jsonrpc: Arc<str>,
+    pub error: T, // TODO use standard structure
+}
+
+impl<T> JsonRpcResponseError<T> {
+    pub fn new(id: MessageId, error: T) -> Self {
+        Self {
+            id,
+            jsonrpc: JSON_RPC_VERSION.clone(),
+            error,
         }
     }
 }

--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -14,49 +14,48 @@ use {
 };
 
 #[derive(Debug, thiserror::Error)]
-#[repr(i16)]
 pub enum RelayMessageClientError {
     #[error("No project found associated with topic {0}")]
-    WrongNotifySubscribeTopic(Topic) = 0,
+    WrongNotifySubscribeTopic(Topic),
 
     #[error("Received 4010 on wrong topic: {0}")]
-    WrongNotifyWatchSubscriptionsTopic(Topic) = 1,
+    WrongNotifyWatchSubscriptionsTopic(Topic),
 
     #[error("Subscription watcher limit reached")]
-    SubscriptionWatcherLimitReached = 2,
+    SubscriptionWatcherLimitReached,
 
     #[error("Received 4008 on unrecognized topic: {0}")]
-    WrongNotifyUpdateTopic(Topic) = 3,
+    WrongNotifyUpdateTopic(Topic),
 
     #[error("Received 4004 on unrecognized topic: {0}")]
-    WrongNotifyDeleteTopic(Topic) = 4,
+    WrongNotifyDeleteTopic(Topic),
 
     #[error("Received 4014 on unrecognized topic: {0}")]
-    WrongNotifyGetNotificationsTopic(Topic) = 5,
+    WrongNotifyGetNotificationsTopic(Topic),
 
     #[error("No project found associated with app_domain {0}")]
-    NotifyWatchSubscriptionsAppDomainNotFound(Arc<str>) = 6,
+    NotifyWatchSubscriptionsAppDomainNotFound(Arc<str>),
 
     #[error("The requested app does not match the project's app domain")]
-    AppDoesNotMatch = 7,
+    AppDoesNotMatch,
 
     #[error("Decode message: {0}")]
-    DecodeMessage(#[from] base64::DecodeError) = 8,
+    DecodeMessage(#[from] base64::DecodeError),
 
     #[error("Could not parse message envelope: {0}")]
-    EnvelopeParseError(#[from] EnvelopeParseError) = 9,
+    EnvelopeParseError(#[from] EnvelopeParseError),
 
     #[error(transparent)]
-    RateLimitExceeded(RateLimitExceeded) = 10,
+    RateLimitExceeded(RateLimitExceeded),
 
     #[error("Not authorized to control that app's subscriptions")]
-    AppSubscriptionsUnauthorized = 11,
+    AppSubscriptionsUnauthorized,
 
     #[error("JWT parse/verification error: {0}")]
-    JwtError(JwtError) = 12,
+    JwtError(JwtError),
 
     #[error(transparent)]
-    IdentityVerification(IdentityVerificationClientError) = 13,
+    IdentityVerification(IdentityVerificationClientError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -3,14 +3,24 @@ use {
         analytics::subscriber_update::{NotifyClientMethod, SubscriberUpdateParams},
         auth::{
             add_ttl, from_jwt, sign_jwt, verify_identity, AuthError, Authorization, AuthorizedApp,
-            DidWeb, SharedClaims, SubscriptionDeleteRequestAuth, SubscriptionDeleteResponseAuth,
+            DidWeb, NotifyServerSubscription, SharedClaims, SubscriptionDeleteRequestAuth,
+            SubscriptionDeleteResponseAuth,
         },
         error::NotifyServerError,
-        model::helpers::{delete_subscriber, get_project_by_id, get_subscriber_by_topic},
+        model::{
+            helpers::{
+                delete_subscriber, get_project_by_id, get_subscriber_by_topic, SubscriberWithScope,
+                SubscriptionWatcherQuery,
+            },
+            types::Project,
+        },
         publish_relay_message::publish_relay_message,
         rate_limit::{self, Clock, RateLimitError},
         registry::storage::redis::Redis,
-        rpc::{decode_key, JsonRpcResponse, NotifyDelete, ResponseAuth},
+        rpc::{
+            decode_key, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseError, NotifyDelete,
+            ResponseAuth,
+        },
         services::public_http_server::handlers::relay_webhook::{
             error::{RelayMessageClientError, RelayMessageError, RelayMessageServerError},
             handlers::{
@@ -42,19 +52,17 @@ use {
 
 // TODO make and test idempotency
 pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), RelayMessageError> {
-    let topic = msg.topic;
-
     if let Some(redis) = state.redis.as_ref() {
-        notify_delete_rate_limit(redis, &topic, &state.clock).await?;
+        notify_delete_rate_limit(redis, &msg.topic, &state.clock).await?;
     }
 
     // TODO combine these two SQL queries
     let subscriber =
-        get_subscriber_by_topic(topic.clone(), &state.postgres, state.metrics.as_ref())
+        get_subscriber_by_topic(msg.topic.clone(), &state.postgres, state.metrics.as_ref())
             .await
             .map_err(|e| match e {
                 sqlx::Error::RowNotFound => RelayMessageError::Client(
-                    RelayMessageClientError::WrongNotifyDeleteTopic(topic.clone()),
+                    RelayMessageClientError::WrongNotifyDeleteTopic(msg.topic.clone()),
                 ),
                 e => {
                     RelayMessageError::Server(RelayMessageServerError::NotifyServerError(e.into()))
@@ -77,118 +85,138 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let sym_key =
         decode_key(&subscriber.sym_key).map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-
-    let msg = decrypt_message::<NotifyDelete, _>(envelope, &sym_key)
-        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {}", msg.id);
-    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {}", msg.method); // TODO verify this
-
-    let request_auth = from_jwt::<SubscriptionDeleteRequestAuth>(&msg.params.delete_auth)
-        .map_err(RelayMessageClientError::JwtError)?;
-    info!(
-        "request_auth.shared_claims.iss: {:?}",
-        request_auth.shared_claims.iss
-    );
-    let request_iss_client_id = DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
-        .map_err(AuthError::JwtIssNotDidKey)
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
-
-    if request_auth.app.domain() != project.app_domain {
-        Err(RelayMessageClientError::AppDoesNotMatch)?;
+    if msg.topic != topic_from_key(&sym_key) {
+        return Err(RelayMessageServerError::NotifyServerError(
+            NotifyServerError::TopicDoesNotMatchKey,
+        ))?; // TODO change to client error?
     }
 
-    let (account, siwe_domain) = {
-        if request_auth.shared_claims.act != NOTIFY_DELETE_ACT {
-            return Err(AuthError::InvalidAct)
-                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
-            // TODO change to client error?
+    let req = decrypt_message::<NotifyDelete, _>(envelope, &sym_key)
+        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+
+    async fn handle(
+        state: &AppState,
+        msg: &RelayIncomingMessage,
+        req: &JsonRpcRequest<NotifyDelete>,
+        subscriber: &SubscriberWithScope,
+        project: &Project,
+        project_client_id: DecodedClientId,
+    ) -> Result<
+        (
+            ResponseAuth,
+            Vec<(SubscriptionWatcherQuery, Vec<NotifyServerSubscription>)>,
+        ),
+        RelayMessageError,
+    > {
+        info!("req.id: {}", req.id);
+        info!("req.jsonrpc: {}", req.jsonrpc); // TODO verify this
+        info!("req.method: {}", req.method); // TODO verify this
+
+        let request_auth = from_jwt::<SubscriptionDeleteRequestAuth>(&req.params.delete_auth)
+            .map_err(RelayMessageClientError::JwtError)?;
+        info!(
+            "request_auth.shared_claims.iss: {:?}",
+            request_auth.shared_claims.iss
+        );
+        let request_iss_client_id =
+            DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
+                .map_err(AuthError::JwtIssNotDidKey)
+                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+
+        if request_auth.app.domain() != project.app_domain {
+            Err(RelayMessageClientError::AppDoesNotMatch)?;
         }
 
-        let Authorization {
-            account,
-            app,
-            domain,
-        } = verify_identity(
-            &request_iss_client_id,
-            &request_auth.ksu,
-            &request_auth.sub,
-            state.redis.as_ref(),
-            &state.provider,
-            state.metrics.as_ref(),
-        )
-        .await?;
-
-        // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
-
-        if let AuthorizedApp::Limited(app) = app {
-            if app != project.app_domain {
-                Err(RelayMessageClientError::AppSubscriptionsUnauthorized)?;
+        let (account, siwe_domain) = {
+            if request_auth.shared_claims.act != NOTIFY_DELETE_ACT {
+                return Err(AuthError::InvalidAct)
+                    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
+                // TODO change to client error?
             }
-        }
 
-        if !is_same_address(&account, &subscriber.account) {
-            Err(RelayMessageServerError::NotifyServerError(
-                NotifyServerError::AccountNotAuthorized,
-            ))?; // TODO change to client error?
-        }
+            let Authorization {
+                account,
+                app,
+                domain,
+            } = verify_identity(
+                &request_iss_client_id,
+                &request_auth.ksu,
+                &request_auth.sub,
+                state.redis.as_ref(),
+                &state.provider,
+                state.metrics.as_ref(),
+            )
+            .await?;
 
-        (account, domain)
-    };
+            // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
 
-    delete_subscriber(subscriber.id, &state.postgres, state.metrics.as_ref())
-        .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+            if let AuthorizedApp::Limited(app) = app {
+                if app != project.app_domain {
+                    Err(RelayMessageClientError::AppSubscriptionsUnauthorized)?;
+                }
+            }
 
-    // TODO do in same txn as delete_subscriber()
-    state
-        .notify_webhook(
-            project.project_id.as_ref(),
-            WebhookNotificationEvent::Unsubscribed,
-            subscriber.account.as_ref(),
+            if !is_same_address(&account, &subscriber.account) {
+                Err(RelayMessageServerError::NotifyServerError(
+                    NotifyServerError::AccountNotAuthorized,
+                ))?; // TODO change to client error?
+            }
+
+            (account, domain)
+        };
+
+        delete_subscriber(subscriber.id, &state.postgres, state.metrics.as_ref())
+            .await
+            .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+
+        // TODO do in same txn as delete_subscriber()
+        state
+            .notify_webhook(
+                project.project_id.as_ref(),
+                WebhookNotificationEvent::Unsubscribed,
+                subscriber.account.as_ref(),
+            )
+            .await
+            .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+
+        tokio::task::spawn({
+            let relay_client = state.relay_client.clone();
+            let topic = msg.topic.clone();
+            async move {
+                // Relay ignores subscription_id, generate a random one since we don't have it here.
+                // https://walletconnect.slack.com/archives/C05ABTQSPFY/p1706337410799659?thread_ts=1706307603.828609&cid=C05ABTQSPFY
+                let subscription_id = SubscriptionId::generate();
+                if let Err(e) = relay_client.unsubscribe(topic, subscription_id).await {
+                    warn!("Error unsubscribing Notify from topic: {}", e);
+                }
+            }
+        });
+
+        state.analytics.client(SubscriberUpdateParams {
+            project_pk: project.id,
+            project_id: project.project_id.clone(),
+            pk: subscriber.id,
+            account: subscriber.account.clone(), // Use a consistent account for analytics rather than the per-request one
+            updated_by_iss: request_auth.shared_claims.iss.clone().into(),
+            updated_by_domain: siwe_domain,
+            method: NotifyClientMethod::Unsubscribe,
+            old_scope: subscriber.scope.iter().cloned().map(Into::into).collect(),
+            new_scope: HashSet::new(),
+            notification_topic: subscriber.topic.clone(),
+            topic: msg.topic.clone(),
+        });
+
+        let (sbs, watchers_with_subscriptions) = prepare_subscription_watchers(
+            &request_iss_client_id,
+            &request_auth.shared_claims.mjv,
+            &account,
+            &project.app_domain,
+            &state.postgres,
+            state.metrics.as_ref(),
         )
         .await
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
 
-    tokio::task::spawn({
-        let relay_client = state.relay_client.clone();
-        let topic = topic.clone();
-        async move {
-            // Relay ignores subscription_id, generate a random one since we don't have it here.
-            // https://walletconnect.slack.com/archives/C05ABTQSPFY/p1706337410799659?thread_ts=1706307603.828609&cid=C05ABTQSPFY
-            let subscription_id = SubscriptionId::generate();
-            if let Err(e) = relay_client.unsubscribe(topic, subscription_id).await {
-                warn!("Error unsubscribing Notify from topic: {}", e);
-            }
-        }
-    });
-
-    state.analytics.client(SubscriberUpdateParams {
-        project_pk: project.id,
-        project_id: project.project_id,
-        pk: subscriber.id,
-        account: subscriber.account, // Use a consistent account for analytics rather than the per-request one
-        updated_by_iss: request_auth.shared_claims.iss.clone().into(),
-        updated_by_domain: siwe_domain,
-        method: NotifyClientMethod::Unsubscribe,
-        old_scope: subscriber.scope.into_iter().map(Into::into).collect(),
-        new_scope: HashSet::new(),
-        notification_topic: subscriber.topic,
-        topic,
-    });
-
-    let (sbs, watchers_with_subscriptions) = prepare_subscription_watchers(
-        &request_iss_client_id,
-        &request_auth.shared_claims.mjv,
-        &account,
-        &project.app_domain,
-        &state.postgres,
-        state.metrics.as_ref(),
-    )
-    .await
-    .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-
-    let response_fut = async {
         let now = Utc::now();
         let response_message = SubscriptionDeleteResponseAuth {
             shared_claims: SharedClaims {
@@ -211,7 +239,28 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             ),
         )
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-        let response = JsonRpcResponse::new(msg.id, ResponseAuth { response_auth });
+
+        Ok((ResponseAuth { response_auth }, watchers_with_subscriptions))
+    }
+
+    let result = handle(state, &msg, &req, &subscriber, &project, project_client_id).await;
+
+    let (response, watchers_with_subscriptions) = match result {
+        Ok((result, watchers_with_subscriptions)) => (
+            serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
+                .map_err(Into::into)
+                .map_err(RelayMessageServerError::NotifyServerError)?,
+            Some(watchers_with_subscriptions),
+        ),
+        Err(e) => (
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+                .map_err(Into::into)
+                .map_err(RelayMessageServerError::NotifyServerError)?,
+            None,
+        ),
+    };
+
+    let response_fut = async {
         let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
             .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
         let base64_notification =
@@ -220,7 +269,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         publish_relay_message(
             &state.relay_client,
             &Publish {
-                topic: topic_from_key(&sym_key),
+                topic: msg.topic,
                 message: base64_notification.into(),
                 tag: NOTIFY_DELETE_RESPONSE_TAG,
                 ttl_secs: NOTIFY_DELETE_RESPONSE_TTL.as_secs() as u32,
@@ -229,22 +278,28 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             state.metrics.as_ref(),
         )
         .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into())) // TODO change to client error?
-    };
-
-    let watcher_fut = async {
-        send_to_subscription_watchers(
-            watchers_with_subscriptions,
-            &state.notify_keys.authentication_secret,
-            &state.notify_keys.authentication_client_id,
-            &state.relay_client,
-            state.metrics.as_ref(),
-        )
-        .await
+        .map_err(Into::into)
         .map_err(RelayMessageServerError::NotifyServerError) // TODO change to client error?
     };
 
-    tokio::try_join!(response_fut, watcher_fut)?;
+    if let Some(watchers_with_subscriptions) = watchers_with_subscriptions {
+        let watcher_fut = async {
+            send_to_subscription_watchers(
+                watchers_with_subscriptions,
+                &state.notify_keys.authentication_secret,
+                &state.notify_keys.authentication_client_id,
+                &state.relay_client,
+                state.metrics.as_ref(),
+            )
+            .await
+            .map_err(Into::into)
+        };
+
+        tokio::try_join!(response_fut, watcher_fut)?;
+    } else {
+        response_fut.await?;
+    }
+
     Ok(())
 }
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -250,7 +250,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             Some(watchers_with_subscriptions),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
                 .map_err(Into::into)
                 .map_err(RelayMessageServerError::NotifyServerError)?,
             None,

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -188,7 +188,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
             .map_err(Into::into)
             .map_err(RelayMessageServerError::NotifyServerError)?,
-        Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+        Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
             .map_err(Into::into)
             .map_err(RelayMessageServerError::NotifyServerError)?,
     };

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -3,13 +3,24 @@ use {
         analytics::subscriber_update::{NotifyClientMethod, SubscriberUpdateParams},
         auth::{
             add_ttl, from_jwt, sign_jwt, verify_identity, AuthError, Authorization, AuthorizedApp,
-            DidWeb, SharedClaims, SubscriptionRequestAuth, SubscriptionResponseAuth,
+            DidWeb, NotifyServerSubscription, SharedClaims, SubscriptionRequestAuth,
+            SubscriptionResponseAuth,
         },
-        model::helpers::{get_project_by_topic, get_welcome_notification, upsert_subscriber},
+        error::NotifyServerError,
+        model::{
+            helpers::{
+                get_project_by_topic, get_welcome_notification, upsert_subscriber,
+                SubscriptionWatcherQuery,
+            },
+            types::Project,
+        },
         publish_relay_message::{publish_relay_message, subscribe_relay_topic},
         rate_limit::{self, Clock, RateLimitError},
         registry::storage::redis::Redis,
-        rpc::{decode_key, derive_key, JsonRpcResponse, NotifySubscribe, ResponseAuth},
+        rpc::{
+            decode_key, derive_key, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseError,
+            NotifySubscribe, ResponseAuth,
+        },
         services::{
             public_http_server::handlers::relay_webhook::{
                 error::{RelayMessageClientError, RelayMessageError, RelayMessageServerError},
@@ -50,17 +61,15 @@ use {
 // TODO test idempotency (create subscriber a second time for the same account)
 #[instrument(name = "wc_notifySubscribe", skip_all)]
 pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), RelayMessageError> {
-    let topic = msg.topic;
-
     if let Some(redis) = state.redis.as_ref() {
-        notify_subscribe_project_rate_limit(redis, &topic, &state.clock).await?;
+        notify_subscribe_project_rate_limit(redis, &msg.topic, &state.clock).await?;
     }
 
-    let project = get_project_by_topic(topic.clone(), &state.postgres, state.metrics.as_ref())
+    let project = get_project_by_topic(msg.topic.clone(), &state.postgres, state.metrics.as_ref())
         .await
         .map_err(|e| match e {
             sqlx::Error::RowNotFound => RelayMessageError::Client(
-                RelayMessageClientError::WrongNotifySubscribeTopic(topic.clone()),
+                RelayMessageClientError::WrongNotifySubscribeTopic(msg.topic.clone()),
             ),
             e => RelayMessageError::Server(RelayMessageServerError::NotifyServerError(e.into())),
         })?;
@@ -82,195 +91,215 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         notify_subscribe_client_rate_limit(redis, &client_public_key, &state.clock).await?;
     }
 
-    let sym_key = derive_key(
-        &client_public_key,
-        &x25519_dalek::StaticSecret::from(
-            decode_key(&project.subscribe_private_key)
-                .map_err(RelayMessageServerError::NotifyServerError)?, // TODO change to client error?
-        ),
-    )
-    .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    let server_public_key = x25519_dalek::StaticSecret::from(
+        decode_key(&project.subscribe_private_key)
+            .map_err(RelayMessageServerError::NotifyServerError)?, // TODO change to client error?
+    );
+
+    let sym_key = derive_key(&client_public_key, &server_public_key)
+        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    if msg.topic != topic_from_key(x25519_dalek::PublicKey::from(&server_public_key).as_bytes()) {
+        return Err(RelayMessageServerError::NotifyServerError(
+            NotifyServerError::TopicDoesNotMatchKey,
+        ))?; // TODO change to client error?
+    }
+
     let response_topic = topic_from_key(&sym_key);
     info!("response_topic: {response_topic}");
 
-    let msg = decrypt_message::<NotifySubscribe, _>(envelope, &sym_key)
+    let req = decrypt_message::<NotifySubscribe, _>(envelope, &sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {}", msg.id);
-    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {}", msg.method); // TODO verify this
 
-    let request_auth = from_jwt::<SubscriptionRequestAuth>(&msg.params.subscription_auth)
-        .map_err(RelayMessageClientError::JwtError)?;
-    info!(
-        "request_auth.shared_claims.iss: {:?}",
-        request_auth.shared_claims.iss
-    );
-    let request_iss_client_id = DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
-        .map_err(AuthError::JwtIssNotDidKey)
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+    async fn handle(
+        state: &AppState,
+        msg: &RelayIncomingMessage,
+        req: &JsonRpcRequest<NotifySubscribe>,
+        project: &Project,
+        project_client_id: DecodedClientId,
+        client_public_key: &PublicKey,
+    ) -> Result<
+        (
+            ResponseAuth,
+            Vec<(SubscriptionWatcherQuery, Vec<NotifyServerSubscription>)>,
+        ),
+        RelayMessageError,
+    > {
+        info!("req.id: {}", req.id);
+        info!("req.jsonrpc: {}", req.jsonrpc); // TODO verify this
+        info!("req.method: {}", req.method); // TODO verify this
 
-    if request_auth.app.domain() != project.app_domain {
-        Err(RelayMessageClientError::AppDoesNotMatch)?;
-    }
+        let request_auth = from_jwt::<SubscriptionRequestAuth>(&req.params.subscription_auth)
+            .map_err(RelayMessageClientError::JwtError)?;
+        info!(
+            "request_auth.shared_claims.iss: {:?}",
+            request_auth.shared_claims.iss
+        );
+        let request_iss_client_id =
+            DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
+                .map_err(AuthError::JwtIssNotDidKey)
+                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
 
-    let (account, siwe_domain) = {
-        if request_auth.shared_claims.act != NOTIFY_SUBSCRIBE_ACT {
-            return Err(AuthError::InvalidAct)
-                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
-            // TODO change to client error?
+        if request_auth.app.domain() != project.app_domain {
+            Err(RelayMessageClientError::AppDoesNotMatch)?;
         }
 
-        let Authorization {
-            account,
-            app,
-            domain,
-        } = verify_identity(
-            &request_iss_client_id,
-            &request_auth.ksu,
-            &request_auth.sub,
-            state.redis.as_ref(),
-            &state.provider,
-            state.metrics.as_ref(),
-        )
-        .await?;
-
-        // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
-
-        if let AuthorizedApp::Limited(app) = app {
-            if app != project.app_domain {
-                Err(RelayMessageClientError::AppSubscriptionsUnauthorized)?;
+        let (account, siwe_domain) = {
+            if request_auth.shared_claims.act != NOTIFY_SUBSCRIBE_ACT {
+                return Err(AuthError::InvalidAct)
+                    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
+                // TODO change to client error?
             }
+
+            let Authorization {
+                account,
+                app,
+                domain,
+            } = verify_identity(
+                &request_iss_client_id,
+                &request_auth.ksu,
+                &request_auth.sub,
+                state.redis.as_ref(),
+                &state.provider,
+                state.metrics.as_ref(),
+            )
+            .await?;
+
+            // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
+
+            if let AuthorizedApp::Limited(app) = app {
+                if app != project.app_domain {
+                    Err(RelayMessageClientError::AppSubscriptionsUnauthorized)?;
+                }
+            }
+
+            // TODO merge code with deployment.rs#verify_jwt()
+            //      - put desired `iss` value as an argument to make sure we verify it
+
+            (account, domain)
+        };
+
+        let scope = parse_scope(&request_auth.scp)
+            .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+
+        let subscriber = {
+            // Technically we don't need to derive based on client_public_key anymore; we just need a symkey. But this is technical
+            // debt from when clients derived the same symkey on their end via Diffie-Hellman. But now they use the value from
+            // watch subscriptions.
+            let secret = StaticSecret::random_from_rng(chacha20poly1305::aead::OsRng);
+            let notify_key = derive_key(client_public_key, &secret)
+                .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+            let notify_topic = topic_from_key(&notify_key);
+
+            info!("Timing: Upserting subscriber");
+            upsert_subscriber(
+                project.id,
+                account.clone(),
+                scope.clone(),
+                &notify_key,
+                notify_topic,
+                &state.postgres,
+                state.metrics.as_ref(),
+            )
+            .await
+            .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))? // TODO change to client error?
+        };
+        info!("Timing: Finished upserting subscriber");
+
+        // TODO do in same txn as upsert_subscriber()
+        if subscriber.inserted {
+            let welcome_notification =
+                get_welcome_notification(project.id, &state.postgres, state.metrics.as_ref())
+                    .await
+                    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+            if let Some(welcome_notification) = welcome_notification {
+                info!("Welcome notification enabled");
+                if welcome_notification.enabled && scope.contains(&welcome_notification.r#type) {
+                    info!("Scope contains welcome notification type, sending welcome notification");
+                    let notification = upsert_notification(
+                        Uuid::new_v4().to_string(),
+                        project.id,
+                        Notification {
+                            r#type: welcome_notification.r#type,
+                            title: welcome_notification.title,
+                            body: welcome_notification.body,
+                            url: welcome_notification.url,
+                            icon: None,
+                        },
+                        &state.postgres,
+                        state.metrics.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+
+                    upsert_subscriber_notifications(
+                        notification.id,
+                        &[subscriber.id],
+                        &state.postgres,
+                        state.metrics.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
+                // TODO change to client error?
+                } else {
+                    info!("Scope does not contain welcome notification type, not sending welcome notification");
+                }
+            } else {
+                info!("Welcome notification not enabled");
+            }
+        } else {
+            info!("Subscriber already existed, not sending welcome notification");
         }
 
-        // TODO merge code with deployment.rs#verify_jwt()
-        //      - put desired `iss` value as an argument to make sure we verify it
-
-        (account, domain)
-    };
-
-    let scope = parse_scope(&request_auth.scp)
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
-
-    let subscriber = {
-        // Technically we don't need to derive based on client_public_key anymore; we just need a symkey. But this is technical
-        // debt from when clients derived the same symkey on their end via Diffie-Hellman. But now they use the value from
-        // watch subscriptions.
-        let secret = StaticSecret::random_from_rng(chacha20poly1305::aead::OsRng);
-        let notify_key = derive_key(&client_public_key, &secret)
+        // TODO do in same transaction as upsert_subscriber()
+        state
+            .notify_webhook(
+                project.project_id.as_ref(),
+                // TODO uncomment when `WebhookNotificationEvent::Updated` exists
+                // if subscriber.inserted {
+                WebhookNotificationEvent::Subscribed,
+                // } else {
+                // WebhookNotificationEvent::Updated
+                // },
+                account.as_ref(),
+            )
+            .await
             .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-        let notify_topic = topic_from_key(&notify_key);
 
-        info!("Timing: Upserting subscriber");
-        upsert_subscriber(
-            project.id,
-            account.clone(),
-            scope.clone(),
-            &notify_key,
-            notify_topic,
+        let notify_topic = subscriber.topic;
+
+        info!("Timing: Subscribing to notify_topic: {notify_topic}");
+        subscribe_relay_topic(&state.relay_client, &notify_topic, state.metrics.as_ref())
+            .await
+            .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
+        info!("Timing: Finished subscribing to topic");
+
+        info!("Timing: Recording SubscriberUpdateParams");
+        state.analytics.client(SubscriberUpdateParams {
+            project_pk: project.id,
+            project_id: project.project_id.clone(),
+            pk: subscriber.id,
+            account: subscriber.account, // Use a consistent account for analytics rather than the per-request one
+            updated_by_iss: request_iss_client_id.to_did_key().into(),
+            updated_by_domain: siwe_domain,
+            method: NotifyClientMethod::Subscribe,
+            old_scope: HashSet::new(),
+            new_scope: scope.clone(),
+            notification_topic: notify_topic.clone(),
+            topic: msg.topic.clone(),
+        });
+        info!("Timing: Finished recording SubscriberUpdateParams");
+
+        let (sbs, watchers_with_subscriptions) = prepare_subscription_watchers(
+            &request_iss_client_id,
+            &request_auth.shared_claims.mjv,
+            &account,
+            &project.app_domain,
             &state.postgres,
             state.metrics.as_ref(),
         )
         .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))? // TODO change to client error?
-    };
-    info!("Timing: Finished upserting subscriber");
-
-    // TODO do in same txn as upsert_subscriber()
-    if subscriber.inserted {
-        let welcome_notification =
-            get_welcome_notification(project.id, &state.postgres, state.metrics.as_ref())
-                .await
-                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
-        if let Some(welcome_notification) = welcome_notification {
-            info!("Welcome notification enabled");
-            if welcome_notification.enabled && scope.contains(&welcome_notification.r#type) {
-                info!("Scope contains welcome notification type, sending welcome notification");
-                let notification = upsert_notification(
-                    Uuid::new_v4().to_string(),
-                    project.id,
-                    Notification {
-                        r#type: welcome_notification.r#type,
-                        title: welcome_notification.title,
-                        body: welcome_notification.body,
-                        url: welcome_notification.url,
-                        icon: None,
-                    },
-                    &state.postgres,
-                    state.metrics.as_ref(),
-                )
-                .await
-                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
-
-                upsert_subscriber_notifications(
-                    notification.id,
-                    &[subscriber.id],
-                    &state.postgres,
-                    state.metrics.as_ref(),
-                )
-                .await
-                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
-            // TODO change to client error?
-            } else {
-                info!("Scope does not contain welcome notification type, not sending welcome notification");
-            }
-        } else {
-            info!("Welcome notification not enabled");
-        }
-    } else {
-        info!("Subscriber already existed, not sending welcome notification");
-    }
-
-    // TODO do in same transaction as upsert_subscriber()
-    state
-        .notify_webhook(
-            project.project_id.as_ref(),
-            // TODO uncomment when `WebhookNotificationEvent::Updated` exists
-            // if subscriber.inserted {
-            WebhookNotificationEvent::Subscribed,
-            // } else {
-            // WebhookNotificationEvent::Updated
-            // },
-            account.as_ref(),
-        )
-        .await
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
 
-    let notify_topic = subscriber.topic;
-
-    info!("Timing: Subscribing to notify_topic: {notify_topic}");
-    subscribe_relay_topic(&state.relay_client, &notify_topic, state.metrics.as_ref())
-        .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
-    info!("Timing: Finished subscribing to topic");
-
-    info!("Timing: Recording SubscriberUpdateParams");
-    state.analytics.client(SubscriberUpdateParams {
-        project_pk: project.id,
-        project_id: project.project_id,
-        pk: subscriber.id,
-        account: subscriber.account, // Use a consistent account for analytics rather than the per-request one
-        updated_by_iss: request_iss_client_id.to_did_key().into(),
-        updated_by_domain: siwe_domain,
-        method: NotifyClientMethod::Subscribe,
-        old_scope: HashSet::new(),
-        new_scope: scope.clone(),
-        notification_topic: notify_topic.clone(),
-        topic,
-    });
-    info!("Timing: Finished recording SubscriberUpdateParams");
-
-    let (sbs, watchers_with_subscriptions) = prepare_subscription_watchers(
-        &request_iss_client_id,
-        &request_auth.shared_claims.mjv,
-        &account,
-        &project.app_domain,
-        &state.postgres,
-        state.metrics.as_ref(),
-    )
-    .await
-    .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-
-    let response_fut = async {
         let now = Utc::now();
         let response_message = SubscriptionResponseAuth {
             shared_claims: SharedClaims {
@@ -293,7 +322,35 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             ),
         )
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-        let response = JsonRpcResponse::new(msg.id, ResponseAuth { response_auth });
+        Ok((ResponseAuth { response_auth }, watchers_with_subscriptions))
+    }
+
+    let result = handle(
+        state,
+        &msg,
+        &req,
+        &project,
+        project_client_id,
+        &client_public_key,
+    )
+    .await;
+
+    let (response, watchers_with_subscriptions) = match result {
+        Ok((result, watchers_with_subscriptions)) => (
+            serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
+                .map_err(Into::into)
+                .map_err(RelayMessageServerError::NotifyServerError)?,
+            Some(watchers_with_subscriptions),
+        ),
+        Err(e) => (
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+                .map_err(Into::into)
+                .map_err(RelayMessageServerError::NotifyServerError)?,
+            None,
+        ),
+    };
+
+    let response_fut = async {
         let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
             .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
         let base64_notification =
@@ -312,24 +369,31 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             state.metrics.as_ref(),
         )
         .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+        .map_err(Into::into)
+        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
         info!("Finished publishing subscribe response");
         Ok(())
     };
 
-    let watcher_fut = async {
-        send_to_subscription_watchers(
-            watchers_with_subscriptions,
-            &state.notify_keys.authentication_secret,
-            &state.notify_keys.authentication_client_id,
-            &state.relay_client,
-            state.metrics.as_ref(),
-        )
-        .await
-        .map_err(RelayMessageServerError::NotifyServerError) // TODO change to client error?
-    };
+    if let Some(watchers_with_subscriptions) = watchers_with_subscriptions {
+        let watcher_fut = async {
+            send_to_subscription_watchers(
+                watchers_with_subscriptions,
+                &state.notify_keys.authentication_secret,
+                &state.notify_keys.authentication_client_id,
+                &state.relay_client,
+                state.metrics.as_ref(),
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(RelayMessageServerError::NotifyServerError)
+        };
 
-    tokio::try_join!(response_fut, watcher_fut)?;
+        tokio::try_join!(response_fut, watcher_fut)?;
+    } else {
+        response_fut.await?;
+    }
+
     Ok(())
 }
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -343,7 +343,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             Some(watchers_with_subscriptions),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
                 .map_err(Into::into)
                 .map_err(RelayMessageServerError::NotifyServerError)?,
             None,

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -246,7 +246,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
             Some(watchers_with_subscriptions),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
                 .map_err(Into::into)
                 .map_err(RelayMessageServerError::NotifyServerError)?,
             None,

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -208,7 +208,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
             .map_err(Into::into)
             .map_err(RelayMessageServerError::NotifyServerError)?,
-        Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+        Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
             .map_err(Into::into)
             .map_err(RelayMessageServerError::NotifyServerError)?,
     };

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -19,8 +19,8 @@ use {
         rate_limit::{self, Clock, RateLimitError},
         registry::storage::redis::Redis,
         rpc::{
-            decode_key, derive_key, JsonRpcRequest, JsonRpcResponse, NotifySubscriptionsChanged,
-            NotifyWatchSubscriptions, ResponseAuth,
+            decode_key, derive_key, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseError,
+            NotifySubscriptionsChanged, NotifyWatchSubscriptions, ResponseAuth,
         },
         services::public_http_server::handlers::relay_webhook::{
             error::{RelayMessageClientError, RelayMessageError, RelayMessageServerError},
@@ -75,59 +75,64 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
     let response_topic = topic_from_key(&response_sym_key);
 
-    let msg = decrypt_message::<NotifyWatchSubscriptions, _>(envelope, &response_sym_key)
+    let req = decrypt_message::<NotifyWatchSubscriptions, _>(envelope, &response_sym_key)
         .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-    info!("msg.id: {}", msg.id);
-    info!("msg.jsonrpc: {}", msg.jsonrpc); // TODO verify this
-    info!("msg.method: {}", msg.method); // TODO verify this
 
-    let id = msg.id;
+    async fn handle(
+        state: &AppState,
+        req: &JsonRpcRequest<NotifyWatchSubscriptions>,
+        response_sym_key: &[u8; 32],
+    ) -> Result<ResponseAuth, RelayMessageError> {
+        info!("req.id: {}", req.id);
+        info!("req.jsonrpc: {}", req.jsonrpc); // TODO verify this
+        info!("req.method: {}", req.method); // TODO verify this
 
-    let request_auth =
-        from_jwt::<WatchSubscriptionsRequestAuth>(&msg.params.watch_subscriptions_auth)
-            .map_err(RelayMessageClientError::JwtError)?;
-    info!(
-        "request_auth.shared_claims.iss: {:?}",
-        request_auth.shared_claims.iss
-    );
-    let request_iss_client_id = DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
-        .map_err(AuthError::JwtIssNotDidKey)
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+        let request_auth =
+            from_jwt::<WatchSubscriptionsRequestAuth>(&req.params.watch_subscriptions_auth)
+                .map_err(RelayMessageClientError::JwtError)?;
+        info!(
+            "request_auth.shared_claims.iss: {:?}",
+            request_auth.shared_claims.iss
+        );
+        let request_iss_client_id =
+            DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
+                .map_err(AuthError::JwtIssNotDidKey)
+                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
 
-    // Verify request
-    let authorization = {
-        if request_auth.shared_claims.act != NOTIFY_WATCH_SUBSCRIPTIONS_ACT {
-            return Err(AuthError::InvalidAct)
-                .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
-            // TODO change to client error?
-        }
+        // Verify request
+        let authorization = {
+            if request_auth.shared_claims.act != NOTIFY_WATCH_SUBSCRIPTIONS_ACT {
+                return Err(AuthError::InvalidAct)
+                    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?;
+                // TODO change to client error?
+            }
 
-        verify_identity(
-            &request_iss_client_id,
-            &request_auth.ksu,
-            &request_auth.sub,
-            state.redis.as_ref(),
-            &state.provider,
-            state.metrics.as_ref(),
-        )
-        .await?
+            verify_identity(
+                &request_iss_client_id,
+                &request_auth.ksu,
+                &request_auth.sub,
+                state.redis.as_ref(),
+                &state.provider,
+                state.metrics.as_ref(),
+            )
+            .await?
 
-        // TODO verify `sub_auth.aud` matches `notify-server.identity_keypair`
+            // TODO verify `sub_auth.aud` matches `notify-server.identity_keypair`
 
-        // TODO merge code with deployment.rs#verify_jwt()
-        //      - put desired `iss` value as an argument to make sure we verify
-        //        it
-    };
-    let account = authorization.account;
+            // TODO merge code with deployment.rs#verify_jwt()
+            //      - put desired `iss` value as an argument to make sure we verify
+            //        it
+        };
+        let account = authorization.account;
 
-    info!("authorization.app: {:?}", authorization.app);
-    info!("request_auth.app: {:?}", request_auth.app);
-    let app_domain = request_auth.app.map(|app| app.domain_arc());
-    info!("app_domain: {app_domain:?}");
-    check_app_authorization(&authorization.app, app_domain.as_deref())
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+        info!("authorization.app: {:?}", authorization.app);
+        info!("request_auth.app: {:?}", request_auth.app);
+        let app_domain = request_auth.app.map(|app| app.domain_arc());
+        info!("app_domain: {app_domain:?}");
+        check_app_authorization(&authorization.app, app_domain.as_deref())
+            .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
 
-    let subscriptions = collect_subscriptions(
+        let subscriptions = collect_subscriptions(
         account.clone(),
         app_domain.as_deref(),
         &state.postgres,
@@ -141,45 +146,44 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     })
     .collect();
 
-    let project = if let Some(app_domain) = app_domain {
-        let project =
-            get_project_by_app_domain(&app_domain, &state.postgres, state.metrics.as_ref())
-                .await
-                .map_err(|e| match e {
-                    sqlx::Error::RowNotFound => RelayMessageError::Client(
-                        RelayMessageClientError::NotifyWatchSubscriptionsAppDomainNotFound(
-                            app_domain,
+        let project = if let Some(app_domain) = app_domain {
+            let project =
+                get_project_by_app_domain(&app_domain, &state.postgres, state.metrics.as_ref())
+                    .await
+                    .map_err(|e| match e {
+                        sqlx::Error::RowNotFound => RelayMessageError::Client(
+                            RelayMessageClientError::NotifyWatchSubscriptionsAppDomainNotFound(
+                                app_domain,
+                            ),
                         ),
-                    ),
-                    e => RelayMessageError::Server(RelayMessageServerError::NotifyServerError(
-                        e.into(),
-                    )),
-                })?;
-        Some(project.id)
-    } else {
-        None
-    };
-    info!("project: {project:?}");
-    upsert_subscription_watcher(
-        account,
-        project,
-        &request_auth.shared_claims.iss,
-        &hex::encode(response_sym_key),
-        Utc::now() + Duration::days(1),
-        &state.postgres,
-        state.metrics.as_ref(),
-    )
-    .await
-    .map_err(|e| match e {
-        UpsertSubscriptionWatcherError::LimitReached => {
-            RelayMessageError::Client(RelayMessageClientError::SubscriptionWatcherLimitReached)
-        }
-        UpsertSubscriptionWatcherError::Sqlx(e) => RelayMessageError::Server(
-            RelayMessageServerError::NotifyServerError(NotifyServerError::Sqlx(e)),
-        ),
-    })?;
+                        e => RelayMessageError::Server(RelayMessageServerError::NotifyServerError(
+                            e.into(),
+                        )),
+                    })?;
+            Some(project.id)
+        } else {
+            None
+        };
+        info!("project: {project:?}");
+        upsert_subscription_watcher(
+            account,
+            project,
+            &request_auth.shared_claims.iss,
+            &hex::encode(response_sym_key),
+            Utc::now() + Duration::days(1),
+            &state.postgres,
+            state.metrics.as_ref(),
+        )
+        .await
+        .map_err(|e| match e {
+            UpsertSubscriptionWatcherError::LimitReached => {
+                RelayMessageError::Client(RelayMessageClientError::SubscriptionWatcherLimitReached)
+            }
+            UpsertSubscriptionWatcherError::Sqlx(e) => RelayMessageError::Server(
+                RelayMessageServerError::NotifyServerError(NotifyServerError::Sqlx(e)),
+            ),
+        })?;
 
-    {
         let now = Utc::now();
         let response_message = WatchSubscriptionsResponseAuth {
             shared_claims: SharedClaims {
@@ -195,28 +199,38 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         };
         let response_auth = sign_jwt(response_message, &state.notify_keys.authentication_secret)
             .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-        let response = JsonRpcResponse::new(id, ResponseAuth { response_auth });
-
-        let envelope = Envelope::<EnvelopeType0>::new(&response_sym_key, response)
-            .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
-        let base64_notification =
-            base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
-
-        info!("Publishing response on topic {response_topic}");
-        publish_relay_message(
-            &state.relay_client,
-            &Publish {
-                topic: response_topic,
-                message: base64_notification.into(),
-                tag: NOTIFY_WATCH_SUBSCRIPTIONS_RESPONSE_TAG,
-                ttl_secs: NOTIFY_WATCH_SUBSCRIPTIONS_RESPONSE_TTL.as_secs() as u32,
-                prompt: false,
-            },
-            state.metrics.as_ref(),
-        )
-        .await
-        .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
+        Ok(ResponseAuth { response_auth })
     }
+
+    let result = handle(state, &req, &response_sym_key).await;
+
+    let response = match result {
+        Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
+            .map_err(Into::into)
+            .map_err(RelayMessageServerError::NotifyServerError)?,
+        Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.to_string()))
+            .map_err(Into::into)
+            .map_err(RelayMessageServerError::NotifyServerError)?,
+    };
+
+    let envelope = Envelope::<EnvelopeType0>::new(&response_sym_key, response)
+        .map_err(RelayMessageServerError::NotifyServerError)?; // TODO change to client error?
+    let base64_notification = base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+
+    info!("Publishing response on topic {response_topic}");
+    publish_relay_message(
+        &state.relay_client,
+        &Publish {
+            topic: response_topic,
+            message: base64_notification.into(),
+            tag: NOTIFY_WATCH_SUBSCRIPTIONS_RESPONSE_TAG,
+            ttl_secs: NOTIFY_WATCH_SUBSCRIPTIONS_RESPONSE_TTL.as_secs() as u32,
+            prompt: false,
+        },
+        state.metrics.as_ref(),
+    )
+    .await
+    .map_err(|e| RelayMessageServerError::NotifyServerError(e.into()))?; // TODO change to client error?
 
     Ok(())
 }
@@ -450,7 +464,7 @@ async fn send(
     );
 
     let sym_key = decode_key(sym_key)?;
-    let envelope = Envelope::<EnvelopeType0>::new(&sym_key, request)?;
+    let envelope = Envelope::<EnvelopeType0>::new(&sym_key, serde_json::to_vec(&request)?)?;
     let base64_notification = base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
 
     let topic = topic_from_key(&sym_key);

--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -314,7 +314,7 @@ async fn process_notification(
     );
 
     let sym_key = decode_key(&notification.subscriber_sym_key)?;
-    let envelope = Envelope::<EnvelopeType0>::new(&sym_key, &message)?;
+    let envelope = Envelope::<EnvelopeType0>::new(&sym_key, serde_json::to_vec(&message)?)?;
     let base64_notification = base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
     let topic = topic_from_key(&sym_key);
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -39,8 +39,7 @@ pub struct Envelope<T> {
 }
 
 impl Envelope<EnvelopeType0> {
-    pub fn new(encryption_key: &[u8; 32], data: impl Serialize) -> Result<Self, NotifyServerError> {
-        let serialized = serde_json::to_vec(&data)?;
+    pub fn new(encryption_key: &[u8; 32], serialized: Vec<u8>) -> Result<Self, NotifyServerError> {
         let iv = generate_nonce();
 
         let cipher = ChaCha20Poly1305::new(GenericArray::from_slice(encryption_key));

--- a/tests/deployment.rs
+++ b/tests/deployment.rs
@@ -176,7 +176,8 @@ async fn deployment_integration() {
         Some(app_domain.clone()),
         &account,
     )
-    .await;
+    .await
+    .unwrap();
     assert!(subs.is_empty());
 
     let notification_type = Uuid::new_v4();
@@ -191,7 +192,8 @@ async fn deployment_integration() {
         app_domain.clone(),
         notification_types.clone(),
     )
-    .await;
+    .await
+    .unwrap();
     let subs = accept_watch_subscriptions_changed(
         &mut relay_client2,
         &notify_server_client_id,
@@ -199,7 +201,8 @@ async fn deployment_integration() {
         &account,
         watch_topic_key,
     )
-    .await;
+    .await
+    .unwrap();
     assert_eq!(subs.len(), 1);
     let sub = &subs[0];
     assert_eq!(sub.account, account);
@@ -246,7 +249,8 @@ async fn deployment_integration() {
         &app_domain,
         &notify_key,
     )
-    .await;
+    .await
+    .unwrap();
 
     assert_eq!(claims.msg.r#type, notification_type);
     assert_eq!(claims.msg.title, "title");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2796,7 +2796,7 @@ pub async fn subscribe_v1(
 pub fn decode_auth_message<T>(
     msg: SubscriptionData,
     key: &[u8; 32],
-) -> Result<(MessageId, T), JsonRpcResponseError<String>>
+) -> Result<(MessageId, T), JsonRpcResponseError>
 where
     T: GetSharedClaims + DeserializeOwned,
 {
@@ -3179,7 +3179,7 @@ async fn get_notifications(
     app_client_id: &DecodedClientId,
     notify_key: [u8; 32],
     params: GetNotificationsParams,
-) -> Result<GetNotificationsResult, JsonRpcResponseError<String>> {
+) -> Result<GetNotificationsResult, JsonRpcResponseError> {
     publish_get_notifications_request(
         relay_client,
         account,

--- a/tests/utils/notify_relay_api.rs
+++ b/tests/utils/notify_relay_api.rs
@@ -91,8 +91,7 @@ pub async fn watch_subscriptions(
     identity_key_details: &IdentityKeyDetails,
     app_domain: Option<DidWeb>,
     account: &AccountId,
-) -> Result<(Vec<NotifyServerSubscription>, [u8; 32], DecodedClientId), JsonRpcResponseError<String>>
-{
+) -> Result<(Vec<NotifyServerSubscription>, [u8; 32], DecodedClientId), JsonRpcResponseError> {
     let (key_agreement_key, client_id) = get_notify_did_json(&notify_server_url).await;
 
     let secret = StaticSecret::random_from_rng(OsRng);
@@ -181,7 +180,7 @@ pub async fn accept_watch_subscriptions_changed(
     identity_key_details: &IdentityKeyDetails,
     account: &AccountId,
     watch_topic_key: [u8; 32],
-) -> Result<Vec<NotifyServerSubscription>, JsonRpcResponseError<String>> {
+) -> Result<Vec<NotifyServerSubscription>, JsonRpcResponseError> {
     let msg = relay_client
         .accept_message(
             NOTIFY_SUBSCRIPTIONS_CHANGED_TAG,
@@ -273,7 +272,7 @@ pub async fn subscribe(
     app_client_id: &DecodedClientId,
     app: DidWeb,
     notification_types: HashSet<Uuid>,
-) -> Result<(), JsonRpcResponseError<String>> {
+) -> Result<(), JsonRpcResponseError> {
     let _subs = subscribe_with_mjv(
         relay_client,
         account,
@@ -298,7 +297,7 @@ pub async fn subscribe_with_mjv(
     app: DidWeb,
     notification_types: HashSet<Uuid>,
     mjv: String,
-) -> Result<Vec<NotifyServerSubscription>, JsonRpcResponseError<String>> {
+) -> Result<Vec<NotifyServerSubscription>, JsonRpcResponseError> {
     let secret = StaticSecret::random_from_rng(OsRng);
     let public = PublicKey::from(&secret);
     let response_topic_key = derive_key(&app_key_agreement_key, &secret).unwrap();
@@ -350,7 +349,7 @@ pub async fn accept_notify_message(
     app_client_id: &DecodedClientId,
     app_domain: &DidWeb,
     notify_key: &[u8; 32],
-) -> Result<(MessageId, NotifyMessage), JsonRpcResponseError<String>> {
+) -> Result<(MessageId, NotifyMessage), JsonRpcResponseError> {
     let msg = client
         .accept_message(NOTIFY_MESSAGE_TAG, &topic_from_key(notify_key))
         .await;

--- a/tests/utils/relay_api.rs
+++ b/tests/utils/relay_api.rs
@@ -17,10 +17,7 @@ use {
     sha2::digest::generic_array::GenericArray,
 };
 
-pub fn decode_message<T>(
-    msg: SubscriptionData,
-    key: &[u8; 32],
-) -> Result<T, JsonRpcResponseError<String>>
+pub fn decode_message<T>(msg: SubscriptionData, key: &[u8; 32]) -> Result<T, JsonRpcResponseError>
 where
     T: DeserializeOwned,
 {
@@ -39,7 +36,7 @@ where
 pub fn decode_response_message<T>(
     msg: SubscriptionData,
     key: &[u8; 32],
-) -> Result<(MessageId, T), JsonRpcResponseError<String>>
+) -> Result<(MessageId, T), JsonRpcResponseError>
 where
     T: GetSharedClaims + DeserializeOwned,
 {


### PR DESCRIPTION
# Description

Sends JSON-RPC error responses when an error is encountered wherever possible rather than not responding at all.

Remaining work:
- [x] Use standard error payload instead of String
- [x] Obscure server error reason
- [ ] ~~Update tests to test client error reason~~ Won't do for now
- [ ] ~~Can more error cases be returned to the client instead of dropped~~ Yes, but not worth it for now
- [ ] ~~Update specs to include error codes~~ Won't do for now; no specific error codes are defined

Resolves #15 

## How Has This Been Tested?

Updated automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
