### PR TITLE
fix: update to latest Relay SDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,7 +3682,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.28.0#f7ff25cae3dec381e5c391a98532dabffd5299d8"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.29.1#243ca2d423076bcec1d4b2a11f6cf6813485bff6"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.28.0#f7ff25cae3dec381e5c391a98532dabffd5299d8"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.29.1#243ca2d423076bcec1d4b2a11f6cf6813485bff6"
 dependencies = [
  "alloy-json-abi",
  "alloy-json-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ futures = "0.3.26"
 futures-util = "0.3"
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.28.0", features = ["cacao"] }
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.28.0" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.29.1", features = ["cacao"] }
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.29.1" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -33,7 +33,7 @@ use {
     chrono::Utc,
     relay_rpc::{
         auth::ed25519_dalek::SigningKey,
-        domain::{DecodedClientId, SubscriptionId, Topic},
+        domain::{DecodedClientId, Topic},
         rpc::Publish,
     },
     std::{collections::HashSet, sync::Arc},
@@ -154,10 +154,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         let relay_client = state.relay_client.clone();
         let topic = topic.clone();
         async move {
-            // Relay ignores subscription_id, generate a random one since we don't have it here.
-            // https://walletconnect.slack.com/archives/C05ABTQSPFY/p1706337410799659?thread_ts=1706307603.828609&cid=C05ABTQSPFY
-            let subscription_id = SubscriptionId::generate();
-            if let Err(e) = relay_client.unsubscribe(topic, subscription_id).await {
+            if let Err(e) = relay_client.unsubscribe(topic).await {
                 warn!("Error unsubscribing Notify from topic: {}", e);
             }
         }


### PR DESCRIPTION
# Description

Update to latest Rust SDK version in order to use new blocking relay functions that return errors.

[Slack conversation](https://walletconnect.slack.com/archives/C03SMNKLPU0/p1710163595419859)

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
