### PR TITLE
fix: reduce logging overhead

### DIFF
--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -65,7 +65,6 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .map_err(RelayMessageClientError::EnvelopeParseError)?;
 
     let client_public_key = x25519_dalek::PublicKey::from(envelope.pubkey());
-    info!("client_public_key: {client_public_key:?}");
 
     if let Some(redis) = state.redis.as_ref() {
         notify_watch_subscriptions_rate_limit(redis, &client_public_key, &state.clock).await?;

--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -177,7 +177,7 @@ pub struct RelayIncomingMessage {
     pub tag: u32,
 }
 
-#[instrument(skip_all, fields(topic = %msg.topic, tag = %msg.tag, message_id = %get_message_id(&msg.message)))]
+#[instrument(skip_all, fields(message_id = %get_message_id(&msg.message)))]
 async fn handle_msg(
     msg: RelayIncomingMessage,
     state: &AppState,

--- a/src/services/public_http_server/mod.rs
+++ b/src/services/public_http_server/mod.rs
@@ -1,7 +1,8 @@
 use {
     crate::{metrics::http_request_middleware, state::AppState},
     axum::{
-        http::{self, HeaderValue}, middleware,
+        http::{self, HeaderValue},
+        middleware,
         routing::{get, post},
         Router,
     },


### PR DESCRIPTION
# Description

- Remove the headers from the request span to reduce logging cost. Only include x-request-id in request span. All other details are logged once at the beginning of request processing.
- Fix that running locally request spans would not show because log level is `WARN,notify_server=DEBUG` and the span was in an external crate
- Remove random `client_public_key` log

Resolves #387 

## How Has This Been Tested?

Locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
