### PR TITLE
fix: log relay error elapsed time

### DIFF
--- a/src/publish_relay_message.rs
+++ b/src/publish_relay_message.rs
@@ -65,7 +65,10 @@ pub async fn publish_relay_message(
         }
 
         if is_permanent {
-            error!("Permanent error publishing message, took {tries} tries: {e:?}");
+            error!(
+                "Permanent error publishing message after {elapsed:?}, took {tries} tries: {e:?}",
+                elapsed = start.elapsed(),
+            );
 
             if let Some(metrics) = metrics {
                 // TODO make DRY with end-of-function call
@@ -76,7 +79,8 @@ pub async fn publish_relay_message(
 
         let retry_in = calculate_retry_in(tries);
         warn!(
-            "Temporary error publishing message, retrying attempt {tries} in {retry_in:?}: {e:?}",
+            "Temporary error publishing message after {elapsed:?}, retrying attempt {tries} in {retry_in:?}: {e:?}",
+            elapsed = start.elapsed(),
         );
         sleep(retry_in).await;
     }
@@ -116,7 +120,10 @@ pub async fn subscribe_relay_topic(
         }
 
         if is_permanent {
-            error!("Permanent error subscribing to topic, took {tries} tries: {e:?}");
+            error!(
+                "Permanent error subscribing to topic after {elapsed:?}, took {tries} tries: {e:?}",
+                elapsed = start.elapsed(),
+            );
 
             if let Some(metrics) = metrics {
                 // TODO make DRY with end-of-function call
@@ -127,7 +134,8 @@ pub async fn subscribe_relay_topic(
 
         let retry_in = calculate_retry_in(tries);
         warn!(
-            "Temporary error subscribing to topic, retrying attempt {tries} in {retry_in:?}: {e:?}"
+            "Temporary error subscribing to topic after {elapsed:?}, retrying attempt {tries} in {retry_in:?}: {e:?}",
+            elapsed = start.elapsed(),
         );
         sleep(retry_in).await;
     }
@@ -172,7 +180,10 @@ pub async fn batch_subscribe_relay_topics(
         }
 
         if is_permanent {
-            error!("Permanent error batch subscribing to topics, took {tries} tries: {e:?}");
+            error!(
+                "Permanent error batch subscribing to topics after {elapsed:?}, took {tries} tries: {e:?}",
+                elapsed = start.elapsed(),
+            );
 
             if let Some(metrics) = metrics {
                 // TODO make DRY with end-of-function call
@@ -183,7 +194,8 @@ pub async fn batch_subscribe_relay_topics(
 
         let retry_in = calculate_retry_in(tries);
         warn!(
-            "Temporary error batch subscribing to topics, retrying attempt {tries} in {retry_in:?}: {e:?}"
+            "Temporary error batch subscribing to topics after {elapsed:?}, retrying attempt {tries} in {retry_in:?}: {e:?}",
+            elapsed = start.elapsed(),
         );
         sleep(retry_in).await;
     }


### PR DESCRIPTION
# Description

Logs how long it took for a relay error to occur. Determines if errors tend to occur immediately (in which case the existing retries solve that) or after 5s+ (in which case adding timeouts will help).

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
