### PR TITLE
fix: use ubuntu-latest runner

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -49,7 +49,7 @@ jobs:
     name: Lookup Version
     if: ${{ inputs.version-type == 'current' }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.1.2
+    uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@fix/use-ubuntu-latest
     with:
       task-name: ${{ vars.IMAGE_NAME }}
       aws-region: ${{ vars.AWS_REGION }}
@@ -60,8 +60,7 @@ jobs:
     name: Select Version
     needs: [ get_deployed_version ]
     if: ${{ always() && !cancelled() && !failure() }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -54,7 +54,6 @@ jobs:
       task-name: ${{ vars.IMAGE_NAME }}
       aws-region: ${{ vars.AWS_REGION }}
       aws-role-arn: ${{vars.AWS_ROLE_PROD}}
-      run-group: ${{ vars.RUN_GROUP }}
 
   select_version:
     name: Select Version

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -49,7 +49,7 @@ jobs:
     name: Lookup Version
     if: ${{ inputs.version-type == 'current' }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@fix/use-ubuntu-latest
+    uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.2.7
     with:
       task-name: ${{ vars.IMAGE_NAME }}
       aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/dispatch_publish.yml
+++ b/.github/workflows/dispatch_publish.yml
@@ -33,7 +33,7 @@ jobs:
 
   release:
     name: Release
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@fix/use-ubuntu-latest
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.7
     secrets: inherit
     with:
       infra-changed: false

--- a/.github/workflows/dispatch_publish.yml
+++ b/.github/workflows/dispatch_publish.yml
@@ -33,7 +33,7 @@ jobs:
 
   release:
     name: Release
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.1.2
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@fix/use-ubuntu-latest
     secrets: inherit
     with:
       infra-changed: false

--- a/.github/workflows/event_intake.yml
+++ b/.github/workflows/event_intake.yml
@@ -11,8 +11,7 @@ jobs:
   add-to-project:
     name: Add issue to board
     if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'accepted'
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.1.0
         with:
@@ -24,8 +23,7 @@ jobs:
   auto-promote:
     name: auto-promote
     if: github.event.action == 'opened'
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Check Core Team membership
         uses: tspascoal/get-user-teams-membership@v1

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -23,8 +23,7 @@ permissions:
 jobs:
   check_pr:
     name: Check PR
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     permissions:
       statuses: write
     steps:
@@ -35,8 +34,7 @@ jobs:
 
   paths-filter:
     name: Paths Filter
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: WalletConnect/actions/github/paths-filter/@2.2.1
@@ -60,7 +58,6 @@ jobs:
     name: Merge Check
     needs: [ check_pr, ci ]
     if: ${{ always() && !cancelled() && !failure() }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - run: echo "CI is successful"

--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -46,7 +46,7 @@ jobs:
   release:
     name: Release
     needs: [ paths_filter ]
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@fix/use-ubuntu-latest
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.7
     secrets: inherit
     with:
       infra-changed: ${{ needs.paths_filter.outputs.infra == 'true' }}

--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -32,8 +32,7 @@ permissions:
 jobs:
   paths_filter:
     name: Paths Filter
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: WalletConnect/actions/github/paths-filter/@2.2.1
@@ -47,7 +46,7 @@ jobs:
   release:
     name: Release
     needs: [ paths_filter ]
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.1.2
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@fix/use-ubuntu-latest
     secrets: inherit
     with:
       infra-changed: ${{ needs.paths_filter.outputs.infra == 'true' }}

--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -31,7 +31,7 @@ jobs:
   cd-staging:
     name: Staging
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@fix/use-ubuntu-latest
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.7
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
@@ -74,7 +74,7 @@ jobs:
     needs: [ validate-staging-health, validate-staging-rust ]
     if: ${{ inputs.deploy-prod }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@fix/use-ubuntu-latest
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.7
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}

--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -31,7 +31,7 @@ jobs:
   cd-staging:
     name: Staging
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.3
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@fix/use-ubuntu-latest
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
@@ -74,7 +74,7 @@ jobs:
     needs: [ validate-staging-health, validate-staging-rust ]
     if: ${{ inputs.deploy-prod }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.3
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@fix/use-ubuntu-latest
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     name: /
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@fix/use-ubuntu-latest
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.7
     with:
       check-infra: ${{ inputs.check-infra }}
       check-app: ${{ inputs.check-app }}

--- a/.github/workflows/sub-ci.yml
+++ b/.github/workflows/sub-ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     name: /
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.3
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@fix/use-ubuntu-latest
     with:
       check-infra: ${{ inputs.check-infra }}
       check-app: ${{ inputs.check-app }}
@@ -36,8 +36,7 @@ jobs:
   integration:
     name: Integration Tests
     if: ${{ inputs.check-app }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     env:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
       RELAY_DOT_ENV: ${{ secrets.RELAY_DOT_ENV }}

--- a/.github/workflows/sub-validate-health.yml
+++ b/.github/workflows/sub-validate-health.yml
@@ -20,8 +20,7 @@ permissions:
 jobs:
   health-check:
     name: Health Check - ${{ inputs.stage }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.stage-url }}

--- a/.github/workflows/sub-validate-rust.yml
+++ b/.github/workflows/sub-validate-rust.yml
@@ -20,8 +20,7 @@ permissions:
 jobs:
   validate-rust:
     name: Rust Deployment Tests - ${{ inputs.stage }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.stage-url }}


### PR DESCRIPTION
# Description

Updates the runners to use `ubuntu-latest` since they were using `ubuntu-runners` group unnecessarily which is expensive.

Remaining work:
- [x] Merge and use tagged version of https://github.com/WalletConnect/ci_workflows/pull/6

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
