### PR TITLE
fix: serialization errors

### DIFF
--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -732,9 +732,11 @@ pub async fn upsert_subscription_watcher(
     let start = Instant::now();
     let mut txn = postgres.begin().await?;
     // https://stackoverflow.com/a/48730873
-    sqlx::query::<Postgres>("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE") // TODO serialization errors not handled
-        .execute(&mut *txn)
-        .await?;
+    // Allow phantom reads; going above the watcher limit is not a big deal and handling
+    // serialization errors is not worth the effort
+    // sqlx::query::<Postgres>("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+    //     .execute(&mut *txn)
+    //     .await?;
     let result = sqlx::query_as::<Postgres, ()>(query)
         .bind(account.as_ref())
         .bind(project)


### PR DESCRIPTION
# Description

Fixes some errors:
- `sqlx error: error returned from database: could not serialize access due to concurrent update`
- `sqlx error: error returned from database: could not serialize access due to read/write dependencies among transactions`

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
