### PR TITLE
fix: worker count going above limit

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -74,6 +74,7 @@ use {
                     upsert_subscriber_notifications, NotificationToProcess,
                 },
                 types::SubscriberNotificationStatus,
+                NOTIFICATION_FOR_DELIVERY,
             },
             relay_mailbox_clearing_service::BATCH_TIMEOUT,
         },
@@ -2604,10 +2605,7 @@ async fn test_dead_letter_and_giveup_checks() {
     let mut pg_listener = sqlx::postgres::PgListener::connect_with(&postgres)
         .await
         .unwrap();
-    pg_listener
-        .listen("notification_for_delivery")
-        .await
-        .unwrap();
+    pg_listener.listen(NOTIFICATION_FOR_DELIVERY).await.unwrap();
     // Spawn a new tokio task for listener
     let (tx, rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {


### PR DESCRIPTION
# Description

Since the worker count was only incremented _after_ spawning the worker, it was possible for the worker spawning loop to spawn more workers than it should. So I refactored the incrementing to take place before spawning.

Also consolidate `load` and `fetch_add|sub`. Since `fetch_*` returns the previous value, we can apply the operation non-atomically to get the resulting value and avoid the second atomic load.

Also relax the ordering from `SeqCst`. I read up on ordering [in the docs](https://doc.rust-lang.org/nomicon/atomics.html) and I think I did it right.

Also refactor `notification_for_delivery` magic string.

Resolves #319 

## How Has This Been Tested?

No new tests because this is a race condition and tough to test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
