### PR TITLE
chore: remove redundant terraform fmt

### DIFF
--- a/justfile
+++ b/justfile
@@ -102,13 +102,6 @@ fmt:
     echo '==> rustfmt not found in PATH, skipping'
   fi
 
-  if command -v terraform -version >/dev/null; then
-    echo '==> Running terraform fmt'
-    terraform -chdir=terraform fmt -recursive
-  else
-    echo '==> terraform not found in PATH, skipping'
-  fi
-
 fmt-imports:
   #!/bin/bash
   set -euo pipefail


### PR DESCRIPTION
# Description

`tf-fmt` already formats, we don't need this in `fmt` too. `fmt` should just be for cargo

## How Has This Been Tested?

Manually

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
