### PR TITLE
fix: Grafana error logs table

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -60,10 +60,10 @@ dashboard.new(
 .addPanels(layout.generate_grid([
   //////////////////////////////////////////////////////////////////////////////
   row.new('Application'),
-    panels.app.http_request_rate(ds, vars)          { gridPos: pos._3 },
-    panels.app.http_request_latency(ds, vars)       { gridPos: pos._3 },
-    panels.lb.error_5xx(ds, vars)              { gridPos: pos._3 },
-    panels.lb.error_5xx_logs(ds, vars)             { gridPos: pos._3 },
+    panels.app.http_request_rate(ds, vars)          { gridPos: pos._4 },
+    panels.app.http_request_latency(ds, vars)       { gridPos: pos._4 },
+    panels.lb.error_5xx(ds, vars)                   { gridPos: pos._4 },
+    panels.lb.error_5xx_logs(ds, vars)              { gridPos: pos._4 },
 
     panels.app.relay_incoming_message_rate(ds, vars)                { gridPos: pos._6 },
     panels.app.relay_incoming_message_latency(ds, vars)             { gridPos: pos._6 },

--- a/terraform/monitoring/panels/lb/error_4xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_4xx.libsonnet
@@ -11,7 +11,7 @@ local _configuration = defaults.configuration.timeseries
     axisSoftMin = 0,
     axisSoftMax = 200,
   );
-
+# no-op
 local _alert(namespace, env, notifications) = grafana.alert.new(
   namespace     = namespace,
   name          = "%(env)s - 4XX alert"     % { env: grafana.utils.strings.capitalize(env) },

--- a/terraform/monitoring/panels/lb/error_5xx_logs.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx_logs.libsonnet
@@ -8,7 +8,7 @@ local targets   = grafana.targets;
 
 {
   new(ds, vars)::
-    panels.timeseries(
+    panels.table(
       title       = 'HTTP 5xx Errors',
       datasource  = ds.cloudwatch,
     )


### PR DESCRIPTION
# Description

Fixes that the error logs cell was disabling as a timeseries rather than a table.

Fixes that the dashboard cells were wider than they were supposed to be.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
