### PR TITLE
feat: read state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,10 +2462,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "if_chain"
-version = "1.0.2"
+name = "idna"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "impl-codec"
@@ -4606,6 +4651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5221,7 +5272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.4.0",
  "percent-encoding",
  "serde",
 ]
@@ -5250,12 +5301,12 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+checksum = "da339118f018cc70ebf01fafc103360528aad53717e4bf311db929cb01cb9345"
 dependencies = [
- "idna",
- "lazy_static",
+ "idna 0.5.0",
+ "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -5266,28 +5317,16 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+checksum = "76e88ea23b8f5e59230bff8a2f03c0ee0054a61d5b8343a38946bcd406fe624c"
 dependencies = [
- "if_chain",
- "lazy_static",
+ "darling",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
- "syn 1.0.109",
- "validator_types",
-]
-
-[[package]]
-name = "validator_types"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ sqlx = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", 
 wiremock = "0.5.19"
 itertools = "0.11.0"
 sha3 = "0.10.8"
-validator = { version = "0.16.1", features = ["derive"] }
+validator = { version = "0.17.0", features = ["derive"] }
 k256 = "0.13.1"
 
 [dev-dependencies]

--- a/migrations/20240319001421_is_read.sql
+++ b/migrations/20240319001421_is_read.sql
@@ -1,1 +1,2 @@
 ALTER TABLE subscriber_notification ADD COLUMN is_read BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX subscriber_notification_is_read_idx  ON subscriber_notification (is_read);

--- a/migrations/20240319001421_is_read.sql
+++ b/migrations/20240319001421_is_read.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriber_notification ADD COLUMN is_read BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/analytics/mark_notifications_as_read.rs
+++ b/src/analytics/mark_notifications_as_read.rs
@@ -19,7 +19,6 @@ pub struct MarkNotificationsAsReadParams {
     pub notification_topic: Topic,
     pub subscriber_notification_pk: Uuid,
     pub notification_pk: Uuid,
-    pub notification_type: Uuid,
     pub marked_count: usize,
 }
 
@@ -49,8 +48,6 @@ pub struct MarkNotificationsAsRead {
     pub subscriber_notification_pk: String,
     /// Primary key of the notification in the Notify Server database
     pub notification_pk: String,
-    /// The notification type ID
-    pub notification_type: String,
     /// The total number of notifications returned in the request
     pub marked_count: usize,
 }
@@ -70,7 +67,6 @@ impl From<MarkNotificationsAsReadParams> for MarkNotificationsAsRead {
             notification_topic: params.notification_topic.into_value(),
             subscriber_notification_pk: params.subscriber_notification_pk.to_string(),
             notification_pk: params.notification_pk.to_string(),
-            notification_type: params.notification_type.to_string(),
             marked_count: params.marked_count,
         }
     }

--- a/src/analytics/mark_notifications_as_read.rs
+++ b/src/analytics/mark_notifications_as_read.rs
@@ -1,0 +1,77 @@
+use {
+    crate::model::types::AccountId,
+    parquet_derive::ParquetRecordWriter,
+    relay_rpc::domain::{ProjectId, Topic},
+    serde::Serialize,
+    std::sync::Arc,
+    uuid::Uuid,
+};
+
+pub struct MarkNotificationsAsReadParams {
+    pub topic: Topic,
+    pub message_id: Arc<str>,
+    pub by_iss: Arc<str>,
+    pub by_domain: Arc<str>,
+    pub project_pk: Uuid,
+    pub project_id: ProjectId,
+    pub subscriber_pk: Uuid,
+    pub subscriber_account: AccountId,
+    pub notification_topic: Topic,
+    pub subscriber_notification_pk: Uuid,
+    pub notification_pk: Uuid,
+    pub notification_type: Uuid,
+    pub marked_count: usize,
+}
+
+#[derive(Debug, Serialize, ParquetRecordWriter)]
+pub struct MarkNotificationsAsRead {
+    /// Time at which the event was generated
+    pub event_at: chrono::NaiveDateTime,
+    /// The relay topic used to manage the subscription that the get notifications request message was published to
+    pub topic: Arc<str>,
+    /// Relay message ID of request
+    pub message_id: Arc<str>,
+    /// JWT iss that made the request
+    pub get_by_iss: Arc<str>,
+    /// CACAO domain that made the request
+    pub get_by_domain: Arc<str>,
+    /// Primary key of the project in the Notify Server database that the subscriber is subscribed to
+    pub project_pk: String,
+    /// Project ID of the project that the subscriber is subscribed to
+    pub project_id: Arc<str>,
+    /// Primary Key of the subscriber in the Notify Server database
+    pub subscriber_pk: String,
+    /// Hash of the CAIP-10 account of the subscriber
+    pub subscriber_account_hash: String,
+    /// The topic that notifications are sent on
+    pub notification_topic: Arc<str>,
+    /// Primary key of the subscriber-specific notification in the Notify Server database
+    pub subscriber_notification_pk: String,
+    /// Primary key of the notification in the Notify Server database
+    pub notification_pk: String,
+    /// The notification type ID
+    pub notification_type: String,
+    /// The total number of notifications returned in the request
+    pub marked_count: usize,
+}
+
+impl From<MarkNotificationsAsReadParams> for MarkNotificationsAsRead {
+    fn from(params: MarkNotificationsAsReadParams) -> Self {
+        Self {
+            event_at: wc::analytics::time::now(),
+            topic: params.topic.into_value(),
+            message_id: params.message_id,
+            get_by_iss: params.by_iss,
+            get_by_domain: params.by_domain,
+            project_pk: params.project_pk.to_string(),
+            project_id: params.project_id.into_value(),
+            subscriber_pk: params.subscriber_pk.to_string(),
+            subscriber_account_hash: sha256::digest(params.subscriber_account.as_ref()),
+            notification_topic: params.notification_topic.into_value(),
+            subscriber_notification_pk: params.subscriber_notification_pk.to_string(),
+            notification_pk: params.notification_pk.to_string(),
+            notification_type: params.notification_type.to_string(),
+            marked_count: params.marked_count,
+        }
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -137,6 +137,8 @@ pub struct NotifyServerSubscription {
     pub scope: HashSet<Uuid>, // TODO 15 hard limit
     /// Unix timestamp of expiration
     pub expiry: u64,
+    /// Number of unread notifications
+    pub unread_notification_count: u64,
 }
 
 impl GetSharedClaims for WatchSubscriptionsResponseAuth {

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -838,6 +838,7 @@ pub struct Notification {
     pub body: String,
     pub icon: Option<String>,
     pub url: Option<String>,
+    pub is_read: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -889,6 +890,7 @@ pub async fn get_notifications_for_subscriber(
         SELECT
             notification.id AS notification_id,
             subscriber_notification.id AS id,
+            subscriber_notification.is_read as is_read,
             CAST(EXTRACT(EPOCH FROM subscriber_notification.created_at AT TIME ZONE 'UTC') * 1000 AS int8) AS sent_at,
             notification.type,
             notification.title,

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -1113,6 +1113,7 @@ pub async fn mark_notifications_as_read(
         UPDATE subscriber_notification
         SET is_read=true
         WHERE subscriber=$1
+            AND is_read=false
             {in_clause}
         RETURNING
             subscriber_notification.id AS subscriber_notification_id,

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -674,7 +674,6 @@ pub async fn get_subscriptions_by_account_and_maybe_app(
     } else {
         ""
     };
-    // unread_notification_count: https://chat.openai.com/share/b8251d6a-5bf1-4dca-b6c5-68f7382d496e
     let query = format!(
         "
         SELECT

--- a/src/model/helpers.rs
+++ b/src/model/helpers.rs
@@ -1103,7 +1103,7 @@ pub async fn mark_notifications_as_read(
 ) -> Result<Vec<MarkNotificationsAsReadResultRow>, sqlx::error::Error> {
     let in_clause = if ids.is_some() {
         "
-        WHERE subscriber_notification.id=ANY($2)
+        AND subscriber_notification.id=ANY($2)
         "
     } else {
         ""
@@ -1112,6 +1112,7 @@ pub async fn mark_notifications_as_read(
         "
         UPDATE subscriber_notification
         SET is_read=true
+        WHERE subscriber=$1
             {in_clause}
         RETURNING
             subscriber_notification.id AS subscriber_notification_id,

--- a/src/notify_message.rs
+++ b/src/notify_message.rs
@@ -63,4 +63,5 @@ pub struct JwtNotification {
     pub body: String,
     pub icon: String,
     pub url: String,
+    pub is_read: bool,
 }

--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -129,8 +129,8 @@ impl From<IdentityVerificationError> for RelayMessageError {
     }
 }
 
-impl From<RelayMessageError> for JsonRpcError {
-    fn from(err: RelayMessageError) -> Self {
+impl From<&RelayMessageError> for JsonRpcError {
+    fn from(err: &RelayMessageError) -> Self {
         match err {
             RelayMessageError::Client(err) => JsonRpcError {
                 message: err.to_string(),

--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -37,6 +37,9 @@ pub enum RelayMessageClientError {
     #[error("Received 4014 on unrecognized topic: {0}")]
     WrongNotifyGetNotificationsTopic(Topic),
 
+    #[error("Received 4016 on unrecognized topic: {0}")]
+    WrongNotifyMarkNotificationsAsReadTopic(Topic),
+
     #[error("No project found associated with app_domain {0}")]
     NotifyWatchSubscriptionsAppDomainNotFound(Arc<str>),
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/mod.rs
@@ -8,6 +8,7 @@ use {
 
 pub mod notify_delete;
 pub mod notify_get_notifications;
+pub mod notify_mark_notifications_as_read;
 pub mod notify_subscribe;
 pub mod notify_update;
 pub mod notify_watch_subscriptions;

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -171,6 +171,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
                 })
                 .collect(),
             has_more: data.has_more,
+            has_more_unread: data.has_more_unread,
         };
 
         let relay_message_id: Arc<str> = get_message_id(msg.message.as_ref()).into();

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -32,7 +32,7 @@ use {
         },
         state::AppState,
         types::{Envelope, EnvelopeType0},
-        utils::topic_from_key,
+        utils::{is_same_address, topic_from_key},
     },
     base64::Engine,
     chrono::Utc,
@@ -135,6 +135,12 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
                 if app != project.app_domain {
                     Err(RelayMessageClientError::AppSubscriptionsUnauthorized)?;
                 }
+            }
+
+            if !is_same_address(&account, &subscriber.account) {
+                Err(RelayMessageServerError::NotifyServer(
+                    NotifyServerError::AccountNotAuthorized,
+                ))?; // TODO change to client error?
             }
 
             (account, Arc::<str>::from(domain))

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -218,7 +218,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let result = handle(state, &msg, &req, &subscriber, &project).await;
 
-    let response = match result {
+    let response = match &result {
         Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
             .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
         Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
@@ -244,7 +244,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .await
     .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
 
-    Ok(())
+    result.map(|_| ())
 }
 
 pub async fn notify_get_notifications_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_mark_notifications_as_read.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_mark_notifications_as_read.rs
@@ -1,0 +1,253 @@
+use {
+    crate::{
+        analytics::mark_notifications_as_read::MarkNotificationsAsReadParams,
+        auth::{
+            add_ttl, from_jwt, sign_jwt, verify_identity, AuthError, Authorization, AuthorizedApp,
+            DidWeb, SharedClaims, SubscriptionMarkNotificationsAsReadRequestAuth,
+            SubscriptionMarkNotificationsAsReadResponseAuth,
+        },
+        error::NotifyServerError,
+        model::{
+            helpers::{
+                get_project_by_id, get_subscriber_by_topic, mark_notifications_as_read,
+                SubscriberWithScope,
+            },
+            types::Project,
+        },
+        publish_relay_message::publish_relay_message,
+        rate_limit::{self, Clock, RateLimitError},
+        registry::storage::redis::Redis,
+        rpc::{decode_key, AuthMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseError},
+        services::public_http_server::handlers::relay_webhook::{
+            error::{RelayMessageClientError, RelayMessageError, RelayMessageServerError},
+            handlers::decrypt_message,
+            RelayIncomingMessage,
+        },
+        spec::{
+            NOTIFY_GET_NOTIFICATIONS_ACT, NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_ACT,
+            NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TAG,
+            NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TTL,
+        },
+        state::AppState,
+        types::{Envelope, EnvelopeType0},
+        utils::topic_from_key,
+    },
+    base64::Engine,
+    chrono::Utc,
+    relay_rpc::{
+        auth::ed25519_dalek::SigningKey,
+        domain::{DecodedClientId, Topic},
+        rpc::{msg_id::get_message_id, Publish},
+    },
+    std::sync::Arc,
+    tracing::info,
+};
+
+// TODO test idempotency
+pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), RelayMessageError> {
+    if let Some(redis) = state.redis.as_ref() {
+        notify_mark_notifications_as_read_rate_limit(redis, &msg.topic, &state.clock).await?;
+    }
+
+    // TODO combine these two SQL queries
+    let subscriber =
+        get_subscriber_by_topic(msg.topic.clone(), &state.postgres, state.metrics.as_ref())
+            .await
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => RelayMessageError::Client(
+                    RelayMessageClientError::WrongNotifyMarkNotificationsAsReadTopic(
+                        msg.topic.clone(),
+                    ),
+                ),
+                e => RelayMessageError::Server(RelayMessageServerError::NotifyServer(e.into())),
+            })?;
+    let project = get_project_by_id(subscriber.project, &state.postgres, state.metrics.as_ref())
+        .await
+        .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
+
+    let envelope = Envelope::<EnvelopeType0>::from_bytes(
+        base64::engine::general_purpose::STANDARD
+            .decode(msg.message.to_string())
+            .map_err(RelayMessageClientError::DecodeMessage)?,
+    )
+    .map_err(RelayMessageClientError::EnvelopeParse)?;
+
+    let sym_key = decode_key(&subscriber.sym_key).map_err(RelayMessageServerError::DecodeKey)?;
+    if msg.topic != topic_from_key(&sym_key) {
+        return Err(RelayMessageServerError::NotifyServer(
+            NotifyServerError::TopicDoesNotMatchKey,
+        ))?; // TODO change to client error?
+    }
+
+    let req = decrypt_message::<AuthMessage, _>(envelope, &sym_key)?;
+
+    async fn handle(
+        state: &AppState,
+        msg: &RelayIncomingMessage,
+        req: &JsonRpcRequest<AuthMessage>,
+        subscriber: &SubscriberWithScope,
+        project: &Project,
+    ) -> Result<AuthMessage, RelayMessageError> {
+        info!("req.id: {}", req.id);
+        info!("req.jsonrpc: {}", req.jsonrpc); // TODO verify this
+        info!("req.method: {}", req.method); // TODO verify this
+
+        let request_auth =
+            from_jwt::<SubscriptionMarkNotificationsAsReadRequestAuth>(&req.params.auth)
+                .map_err(RelayMessageClientError::Jwt)?;
+        info!(
+            "request_auth.shared_claims.iss: {:?}",
+            request_auth.shared_claims.iss
+        );
+        let request_iss_client_id =
+            DecodedClientId::try_from_did_key(&request_auth.shared_claims.iss)
+                .map_err(AuthError::JwtIssNotDidKey)
+                .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
+
+        if request_auth.app.domain() != project.app_domain {
+            Err(RelayMessageClientError::AppDoesNotMatch)?;
+        }
+
+        let (account, siwe_domain) = {
+            if request_auth.shared_claims.act != NOTIFY_GET_NOTIFICATIONS_ACT {
+                return Err(AuthError::InvalidAct)
+                    .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?;
+                // TODO change to client error?
+            }
+
+            let Authorization {
+                account,
+                app,
+                domain,
+            } = verify_identity(
+                &request_iss_client_id,
+                &request_auth.ksu,
+                &request_auth.sub,
+                state.redis.as_ref(),
+                state.provider.as_ref(),
+                state.metrics.as_ref(),
+            )
+            .await?;
+
+            // TODO verify `sub_auth.aud` matches `project_data.identity_keypair`
+
+            if let AuthorizedApp::Limited(app) = app {
+                if app != project.app_domain {
+                    Err(RelayMessageClientError::AppSubscriptionsUnauthorized)?;
+                }
+            }
+
+            (account, Arc::<str>::from(domain))
+        };
+
+        request_auth
+            .validate()
+            .map_err(RelayMessageServerError::NotifyServer)?; // TODO change to client error?
+
+        let data = mark_notifications_as_read(
+            subscriber.id,
+            request_auth.params,
+            &state.postgres,
+            state.metrics.as_ref(),
+        )
+        .await
+        .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
+
+        let relay_message_id: Arc<str> = get_message_id(msg.message.as_ref()).into();
+        let marked_count = data.len();
+        for notification in data {
+            state
+                .analytics
+                .mark_notifications_as_read(MarkNotificationsAsReadParams {
+                    topic: msg.topic.clone(),
+                    message_id: relay_message_id.clone(),
+                    by_iss: request_auth.shared_claims.iss.clone().into(),
+                    by_domain: siwe_domain.clone(),
+                    project_pk: project.id,
+                    project_id: project.project_id.clone(),
+                    subscriber_pk: subscriber.id,
+                    subscriber_account: subscriber.account.clone(),
+                    notification_topic: subscriber.topic.clone(),
+                    subscriber_notification_pk: notification.subscriber_notification_id,
+                    notification_pk: notification.notification_id,
+                    notification_type: notification.notification_id,
+                    marked_count,
+                });
+        }
+
+        let identity = DecodedClientId(
+            decode_key(&project.authentication_public_key)
+                .map_err(RelayMessageServerError::DecodeKey)?,
+        );
+
+        let now = Utc::now();
+        let response_message = SubscriptionMarkNotificationsAsReadResponseAuth {
+            shared_claims: SharedClaims {
+                iat: now.timestamp() as u64,
+                exp: add_ttl(now, NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TTL).timestamp()
+                    as u64,
+                iss: identity.to_did_key(),
+                aud: request_iss_client_id.to_did_key(),
+                act: NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_ACT.to_owned(),
+                mjv: "1".to_owned(),
+            },
+            sub: account.to_did_pkh(),
+            app: DidWeb::from_domain(project.app_domain.clone()),
+        };
+        let auth = sign_jwt(
+            response_message,
+            &SigningKey::from_bytes(
+                &decode_key(&project.authentication_private_key)
+                    .map_err(RelayMessageServerError::DecodeKey)?,
+            ),
+        )
+        .map_err(RelayMessageServerError::SignJwt)?;
+        Ok(AuthMessage { auth })
+    }
+
+    let result = handle(state, &msg, &req, &subscriber, &project).await;
+
+    let response = match result {
+        Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
+            .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
+        Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
+            .map_err(RelayMessageServerError::JsonRpcResponseErrorSerialization)?,
+    };
+
+    let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
+        .map_err(RelayMessageServerError::EnvelopeEncryption)?;
+
+    let response = base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+
+    publish_relay_message(
+        &state.relay_client,
+        &Publish {
+            topic: msg.topic,
+            message: response.into(),
+            tag: NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TAG,
+            ttl_secs: NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TTL.as_secs() as u32,
+            prompt: false,
+        },
+        state.metrics.as_ref(),
+    )
+    .await
+    .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
+
+    Ok(())
+}
+
+pub async fn notify_mark_notifications_as_read_rate_limit(
+    redis: &Arc<Redis>,
+    topic: &Topic,
+    clock: &Clock,
+) -> Result<(), RateLimitError> {
+    rate_limit::token_bucket(
+        redis,
+        format!("notify-mark-notifications-as-read-{topic}"),
+        100,
+        chrono::Duration::milliseconds(500),
+        1,
+        clock,
+    )
+    .await
+}

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -333,16 +333,18 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     )
     .await;
 
-    let (response, watchers_with_subscriptions) = match result {
+    let (response, watchers_with_subscriptions, result) = match result {
         Ok((result, watchers_with_subscriptions)) => (
             serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
                 .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
             Some(watchers_with_subscriptions),
+            Ok(()),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, (&e).into()))
                 .map_err(RelayMessageServerError::JsonRpcResponseErrorSerialization)?,
             None,
+            Err(e),
         ),
     };
 
@@ -389,7 +391,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         response_fut.await?;
     }
 
-    Ok(())
+    result
 }
 
 pub async fn notify_subscribe_client_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -234,16 +234,18 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let result = handle(state, &msg, &req, &subscriber, &project, project_client_id).await;
 
-    let (response, watchers_with_subscriptions) = match result {
+    let (response, watchers_with_subscriptions, result) = match result {
         Ok((result, watchers_with_subscriptions)) => (
             serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
                 .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
             Some(watchers_with_subscriptions),
+            Ok(()),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, (&e).into()))
                 .map_err(RelayMessageServerError::JsonRpcResponseErrorSerialization)?,
             None,
+            Err(e),
         ),
     };
 
@@ -287,7 +289,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         response_fut.await?;
     }
 
-    Ok(())
+    result
 }
 
 pub async fn notify_update_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -299,6 +299,7 @@ pub async fn collect_subscriptions(
                         account: sub.account,
                         scope: sub.scope,
                         expiry: sub.expiry.timestamp() as u64,
+                        unread_notification_count: sub.unread_notification_count,
                     })
                 }
                 wrap(sub)

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -206,7 +206,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let result = handle(state, &req, &response_sym_key).await;
 
-    let response = match result {
+    let response = match &result {
         Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
             .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
         Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
@@ -232,7 +232,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .await
     .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
 
-    Ok(())
+    result.map(|_| ())
 }
 
 pub async fn notify_watch_subscriptions_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -5,8 +5,8 @@ use {
         services::public_http_server::handlers::relay_webhook::{
             error::RelayMessageError,
             handlers::{
-                notify_delete, notify_get_notifications, notify_subscribe, notify_update,
-                notify_watch_subscriptions,
+                notify_delete, notify_get_notifications, notify_mark_notifications_as_read,
+                notify_subscribe, notify_update, notify_watch_subscriptions,
             },
         },
         spec,
@@ -191,6 +191,9 @@ async fn handle_msg(
             notify_watch_subscriptions::handle(msg, state).await
         }
         spec::NOTIFY_GET_NOTIFICATIONS_TAG => notify_get_notifications::handle(msg, state).await,
+        spec::NOTIFY_MARK_NOTIFICATIONS_AS_READ_TAG => {
+            notify_mark_notifications_as_read::handle(msg, state).await
+        }
         _ => {
             warn!("Ignored tag {tag} on topic {topic}");
             Ok(())

--- a/src/services/publisher_service/helpers.rs
+++ b/src/services/publisher_service/helpers.rs
@@ -106,6 +106,7 @@ pub struct NotificationToProcess {
     #[sqlx(try_from = "String")]
     pub subscriber_topic: Topic,
     pub subscriber_notification: Uuid,
+    pub subscriber_notification_is_read: bool,
     pub project: Uuid,
     #[sqlx(try_from = "String")]
     pub project_project_id: ProjectId,
@@ -164,6 +165,7 @@ pub async fn pick_subscriber_notification_for_processing(
                 subscriber.sym_key AS subscriber_sym_key,
                 subscriber.topic AS subscriber_topic,
                 subscriber_notification.id AS subscriber_notification,
+                subscriber_notification.is_read AS subscriber_notification_is_read,
                 project.id AS project,
                 project.project_id AS project_project_id,
                 project.app_domain AS project_app_domain,

--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -333,6 +333,7 @@ async fn process_notification(
                                 .to_string()
                         })
                         .unwrap_or_default(),
+                    is_read: notification.subscriber_notification_is_read,
                 }),
                 notification.subscriber_account.clone(),
                 &project_signing_details,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -10,6 +10,7 @@ pub const NOTIFY_MESSAGE_METHOD: &str = "wc_notifyMessage";
 pub const NOTIFY_UPDATE_METHOD: &str = "wc_notifyUpdate";
 pub const NOTIFY_DELETE_METHOD: &str = "wc_notifyDelete";
 pub const NOTIFY_GET_NOTIFICATIONS_METHOD: &str = "wc_notifyGetNotifications";
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_METHOD: &str = "wc_notifyNotificationsChanged";
 
 // Tags
 // https://specs.walletconnect.com/2.0/specs/clients/notify/rpc-methods
@@ -27,8 +28,10 @@ pub const NOTIFY_SUBSCRIPTIONS_CHANGED_TAG: u32 = 4012;
 pub const NOTIFY_SUBSCRIPTIONS_CHANGED_RESPONSE_TAG: u32 = 4013;
 pub const NOTIFY_GET_NOTIFICATIONS_TAG: u32 = 4014;
 pub const NOTIFY_GET_NOTIFICATIONS_RESPONSE_TAG: u32 = 4015;
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_TAG: u32 = 4016;
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TAG: u32 = 4017;
 
-pub const INCOMING_TAGS: [u32; 7] = [
+pub const INCOMING_TAGS: [u32; 8] = [
     NOTIFY_SUBSCRIBE_TAG,
     NOTIFY_MESSAGE_RESPONSE_TAG,
     NOTIFY_DELETE_TAG,
@@ -36,6 +39,7 @@ pub const INCOMING_TAGS: [u32; 7] = [
     NOTIFY_WATCH_SUBSCRIPTIONS_TAG,
     NOTIFY_SUBSCRIPTIONS_CHANGED_RESPONSE_TAG,
     NOTIFY_GET_NOTIFICATIONS_TAG,
+    NOTIFY_MARK_NOTIFICATIONS_AS_READ_TAG,
 ];
 
 // TTLs
@@ -57,6 +61,8 @@ pub const NOTIFY_SUBSCRIPTIONS_CHANGED_TTL: Duration = T300;
 pub const NOTIFY_SUBSCRIPTIONS_CHANGED_RESPONSE_TTL: Duration = T300;
 pub const NOTIFY_GET_NOTIFICATIONS_TTL: Duration = T300;
 pub const NOTIFY_GET_NOTIFICATIONS_RESPONSE_TTL: Duration = T300;
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_TTL: Duration = T300;
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TTL: Duration = T300;
 
 // acts
 // https://specs.walletconnect.com/2.0/specs/clients/notify/notify-authentication
@@ -75,6 +81,9 @@ pub const NOTIFY_DELETE_ACT: &str = "notify_delete";
 pub const NOTIFY_DELETE_RESPONSE_ACT: &str = "notify_delete_response";
 pub const NOTIFY_GET_NOTIFICATIONS_ACT: &str = "notify_get_notifications";
 pub const NOTIFY_GET_NOTIFICATIONS_RESPONSE_ACT: &str = "notify_get_notifications_response";
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_ACT: &str = "notify_mark_notifications_as_read";
+pub const NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_ACT: &str =
+    "notify_mark_notifications_as_read_response";
 
 #[cfg(test)]
 mod tests {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11900,5 +11900,6 @@ async fn get_notifications_unread() {
 }
 
 // TODO unread first
+// TODO mark all as read
 
 // TODO test is_same_address

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10311,3 +10311,12 @@ async fn notification_link_multiple_subscribers_different_links(
     assert!(location_header.is_some());
     assert_eq!(location_header.unwrap().to_str().unwrap(), test_url);
 }
+
+// TODO mark as read database unit
+
+// TODO Mark as read works integration
+// TODO watchSubscriptions returns unread count
+// TODO getNotifications returns unread status
+// TODO notify message has unread status
+
+// TODO unread first

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11288,6 +11288,18 @@ async fn e2e_mark_notification_as_read(notify_server: &NotifyServerContext) {
     assert_eq!(result.notifications[0].r#type, notification.r#type);
     assert!(!result.notifications[0].is_read);
 
+    let (subs, _watch_topic_key, _notify_server_client_id) = watch_subscriptions(
+        &mut relay_client,
+        notify_server.url.clone(),
+        &identity_key_details,
+        Some(app_domain.clone()),
+        &account,
+    )
+    .await
+    .unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].unread_notification_count, 1);
+
     helper_mark_notifications_as_read(
         &mut relay_client,
         &account,
@@ -11320,12 +11332,21 @@ async fn e2e_mark_notification_as_read(notify_server: &NotifyServerContext) {
     assert_eq!(result.notifications.len(), 1);
     assert_eq!(result.notifications[0].r#type, notification.r#type);
     assert!(result.notifications[0].is_read);
+
+    let (subs, _watch_topic_key, _notify_server_client_id) = watch_subscriptions(
+        &mut relay_client,
+        notify_server.url.clone(),
+        &identity_key_details,
+        Some(app_domain.clone()),
+        &account,
+    )
+    .await
+    .unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].unread_notification_count, 0);
 }
 
-// TODO watchSubscriptions returns unread count
-// TODO getNotifications returns unread status
-// TODO notify message has unread status
-
 // TODO unread first
+// TODO more unread on following pages
 
 // TODO test is_same_address


### PR DESCRIPTION
# Description

Implements support for marking notifications as read as per the [specs](https://github.com/WalletConnect/walletconnect-specs/pull/191).

Resolves #425 

Subsequent PRs will address the remaining TODOs at the end of integration.rs

## How Has This Been Tested?

New tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
