### PR TITLE
fix: errors being excluded from metrics and not being logged

### DIFF
--- a/src/services/public_http_server/handlers/relay_webhook/error.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/error.rs
@@ -129,8 +129,8 @@ impl From<IdentityVerificationError> for RelayMessageError {
     }
 }
 
-impl From<RelayMessageError> for JsonRpcError {
-    fn from(err: RelayMessageError) -> Self {
+impl From<&RelayMessageError> for JsonRpcError {
+    fn from(err: &RelayMessageError) -> Self {
         match err {
             RelayMessageError::Client(err) => JsonRpcError {
                 message: err.to_string(),

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -218,7 +218,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let result = handle(state, &msg, &req, &subscriber, &project).await;
 
-    let response = match result {
+    let response = match &result {
         Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
             .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
         Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
@@ -244,7 +244,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .await
     .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
 
-    Ok(())
+    result.map(|_| ())
 }
 
 pub async fn notify_get_notifications_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -333,16 +333,18 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     )
     .await;
 
-    let (response, watchers_with_subscriptions) = match result {
+    let (response, watchers_with_subscriptions, result) = match result {
         Ok((result, watchers_with_subscriptions)) => (
             serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
                 .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
             Some(watchers_with_subscriptions),
+            Ok(()),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, (&e).into()))
                 .map_err(RelayMessageServerError::JsonRpcResponseErrorSerialization)?,
             None,
+            Err(e),
         ),
     };
 
@@ -389,7 +391,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         response_fut.await?;
     }
 
-    Ok(())
+    result
 }
 
 pub async fn notify_subscribe_client_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -234,16 +234,18 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let result = handle(state, &msg, &req, &subscriber, &project, project_client_id).await;
 
-    let (response, watchers_with_subscriptions) = match result {
+    let (response, watchers_with_subscriptions, result) = match result {
         Ok((result, watchers_with_subscriptions)) => (
             serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
                 .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
             Some(watchers_with_subscriptions),
+            Ok(()),
         ),
         Err(e) => (
-            serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
+            serde_json::to_vec(&JsonRpcResponseError::new(req.id, (&e).into()))
                 .map_err(RelayMessageServerError::JsonRpcResponseErrorSerialization)?,
             None,
+            Err(e),
         ),
     };
 
@@ -287,7 +289,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         response_fut.await?;
     }
 
-    Ok(())
+    result
 }
 
 pub async fn notify_update_rate_limit(

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_watch_subscriptions.rs
@@ -206,7 +206,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
 
     let result = handle(state, &req, &response_sym_key).await;
 
-    let response = match result {
+    let response = match &result {
         Ok(result) => serde_json::to_vec(&JsonRpcResponse::new(req.id, result))
             .map_err(RelayMessageServerError::JsonRpcResponseSerialization)?,
         Err(e) => serde_json::to_vec(&JsonRpcResponseError::new(req.id, e.into()))
@@ -232,7 +232,7 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     .await
     .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?
 
-    Ok(())
+    result.map(|_| ())
 }
 
 pub async fn notify_watch_subscriptions_rate_limit(


### PR DESCRIPTION
# Description

Fixes that client or server errors emitted inside of the `handle()` functions were not being returned from the main handler function and thus were not logged or recorded in metrics.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
