### PR TITLE
feat: mark all as read endpoint

### DIFF
--- a/src/services/public_http_server/handlers/mark_all_as_read.rs
+++ b/src/services/public_http_server/handlers/mark_all_as_read.rs
@@ -1,0 +1,57 @@
+use {
+    crate::{
+        error::NotifyServerError,
+        model::helpers::{get_project_by_project_id, mark_all_notifications_as_read_for_project},
+        rate_limit::{self, Clock, RateLimitError},
+        registry::{extractor::AuthedProjectId, storage::redis::Redis},
+        state::AppState,
+    },
+    axum::{
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+    },
+    relay_rpc::domain::ProjectId,
+    std::sync::Arc,
+    tracing::instrument,
+};
+
+#[instrument(name = "mark_all_as_read", skip(state))]
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    AuthedProjectId(project_id, _): AuthedProjectId,
+) -> Result<Response, NotifyServerError> {
+    if let Some(redis) = state.redis.as_ref() {
+        mark_all_as_read_rate_limit(redis, &project_id, &state.clock).await?;
+    }
+
+    let project = get_project_by_project_id(project_id, &state.postgres, state.metrics.as_ref())
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => {
+                NotifyServerError::UnprocessableEntity("Project not found".into())
+            }
+            e => e.into(),
+        })?;
+
+    mark_all_notifications_as_read_for_project(project.id, &state.postgres, state.metrics.as_ref())
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+pub async fn mark_all_as_read_rate_limit(
+    redis: &Arc<Redis>,
+    project_id: &ProjectId,
+    clock: &Clock,
+) -> Result<(), RateLimitError> {
+    rate_limit::token_bucket(
+        redis,
+        format!("mark_all_as_read-{project_id}"),
+        100,
+        chrono::Duration::minutes(1),
+        1,
+        clock,
+    )
+    .await
+}

--- a/src/services/public_http_server/handlers/mod.rs
+++ b/src/services/public_http_server/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod get_subscribers_v0;
 pub mod get_subscribers_v1;
 pub mod get_welcome_notification;
 pub mod health;
+pub mod mark_all_as_read;
 pub mod notification_link;
 pub mod notify_v0;
 pub mod notify_v1;

--- a/src/services/public_http_server/mod.rs
+++ b/src/services/public_http_server/mod.rs
@@ -89,6 +89,10 @@ pub async fn start(
             "/v0/:project_id/welcome-notification",
             post(handlers::post_welcome_notification::handler),
         )
+        .route(
+            "/v1/:project_id/mark-all-as-read",
+            get(handlers::mark_all_as_read::handler),
+        )
         // FIXME
         // .route(
         //     "/:project_id/register-webhook",


### PR DESCRIPTION
# Description

Implements the `/mark-all-as-read` endpoint as per [the docs](https://github.com/WalletConnect/walletconnect-docs/pull/1376/files#diff-0f8ab41b3b114a3a0dbb28e71db638870aa01d7c93f38a94b3aeb77692a9d8deR211)

Resolves #428 

## How Has This Been Tested?

New tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
