### PR TITLE
fix: request linking

### DIFF
--- a/src/analytics/relay_request.rs
+++ b/src/analytics/relay_request.rs
@@ -1,0 +1,67 @@
+use {
+    crate::services::public_http_server::handlers::relay_webhook::RelayIncomingMessage,
+    chrono::{DateTime, NaiveDateTime, Utc},
+    parquet_derive::ParquetRecordWriter,
+    relay_rpc::domain::Topic,
+    serde::Serialize,
+    std::sync::Arc,
+};
+
+pub struct RelayResponseParams {
+    pub request: Arc<RelayIncomingMessage>,
+
+    pub response_message_id: Arc<str>,
+    pub response_topic: Topic,
+    pub response_tag: u32,
+    pub response_initiated_at: DateTime<Utc>,
+    pub response_finished_at: DateTime<Utc>,
+    pub response_success: bool,
+}
+
+#[derive(Debug, Serialize, ParquetRecordWriter)]
+pub struct RelayRequest {
+    /// Time at which the event was generated
+    pub event_at: NaiveDateTime,
+
+    /// Relay message ID of request
+    pub request_message_id: Arc<str>,
+    /// Relay topic of request
+    pub request_topic: Arc<str>,
+    /// Relay tag of request
+    pub request_tag: u32,
+    /// Time at which the request was received
+    pub request_received_at: NaiveDateTime,
+
+    /// Relay message ID of response
+    pub response_message_id: Arc<str>,
+    /// Relay topic of response
+    pub response_topic: Arc<str>,
+    /// Relay tag of response
+    pub response_tag: u32,
+    /// Time at which the publish request was initiated
+    pub response_initiated_at: NaiveDateTime,
+    /// Time at which the publish request stopped
+    pub response_finished_at: NaiveDateTime,
+    /// If the publish request was ultimatly successful or not
+    pub response_success: bool,
+}
+
+impl From<RelayResponseParams> for RelayRequest {
+    fn from(params: RelayResponseParams) -> Self {
+        Self {
+            event_at: wc::analytics::time::now(),
+
+            request_message_id: params.request.message_id.clone(),
+            request_topic: params.request.topic.value().clone(),
+            request_tag: params.request.tag,
+            request_received_at: params.request.received_at.naive_utc(),
+
+            response_message_id: params.response_message_id.clone(),
+            response_topic: params.response_topic.value().clone(),
+            response_tag: params.response_tag,
+            response_initiated_at: params.response_initiated_at.naive_utc(),
+            response_finished_at: params.response_finished_at.naive_utc(),
+            response_success: params.response_success,
+        }
+    }
+}

--- a/src/publish_relay_message.rs
+++ b/src/publish_relay_message.rs
@@ -1,11 +1,19 @@
 use {
-    crate::metrics::Metrics,
+    crate::{
+        analytics::{relay_request::RelayResponseParams, NotifyAnalytics},
+        metrics::Metrics,
+        services::public_http_server::handlers::relay_webhook::RelayIncomingMessage,
+    },
+    chrono::Utc,
     relay_client::{error::Error, http::Client},
     relay_rpc::{
         domain::Topic,
         rpc::{self, msg_id::get_message_id, Publish, PublishError, SubscriptionError},
     },
-    std::time::{Duration, Instant},
+    std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    },
     tokio::time::sleep,
     tracing::{error, info, instrument, warn},
 };
@@ -22,10 +30,14 @@ fn calculate_retry_in(tries: i32) -> Duration {
 pub async fn publish_relay_message(
     relay_client: &Client,
     publish: &Publish,
+    relay_request: Option<Arc<RelayIncomingMessage>>,
     metrics: Option<&Metrics>,
+    analytics: &NotifyAnalytics,
 ) -> Result<(), Error<PublishError>> {
     info!("publish_relay_message");
     let start = Instant::now();
+
+    let initiated = Utc::now();
 
     let call = || async {
         let start = Instant::now();
@@ -70,10 +82,25 @@ pub async fn publish_relay_message(
                 elapsed = start.elapsed(),
             );
 
+            // TODO make DRY with end-of-function call
             if let Some(metrics) = metrics {
-                // TODO make DRY with end-of-function call
                 metrics.relay_outgoing_message(publish.tag, false, start);
             }
+
+            // TODO make DRY with end-of-function call
+            if let Some(relay_request) = relay_request {
+                let finished = Utc::now();
+                analytics.relay_request(RelayResponseParams {
+                    request: relay_request,
+                    response_message_id: get_message_id(&publish.message).into(),
+                    response_topic: publish.topic.clone(),
+                    response_tag: publish.tag,
+                    response_initiated_at: initiated,
+                    response_finished_at: finished,
+                    response_success: false,
+                });
+            }
+
             return Err(e);
         }
 
@@ -90,6 +117,20 @@ pub async fn publish_relay_message(
     if let Some(metrics) = metrics {
         metrics.relay_outgoing_message(publish.tag, true, start);
     }
+
+    if let Some(relay_request) = relay_request {
+        let finished = Utc::now();
+        analytics.relay_request(RelayResponseParams {
+            request: relay_request,
+            response_message_id: get_message_id(&publish.message).into(),
+            response_topic: publish.topic.clone(),
+            response_tag: publish.tag,
+            response_initiated_at: initiated,
+            response_finished_at: finished,
+            response_success: true,
+        });
+    }
+
     Ok(())
 }
 

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_delete.rs
@@ -253,26 +253,33 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         ),
     };
 
-    let response_fut = async {
-        let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
-            .map_err(RelayMessageServerError::EnvelopeEncryption)?;
-        let base64_notification =
-            base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+    let msg = Arc::from(msg);
 
-        publish_relay_message(
-            &state.relay_client,
-            &Publish {
-                topic: msg.topic,
-                message: base64_notification.into(),
-                tag: NOTIFY_DELETE_RESPONSE_TAG,
-                ttl_secs: NOTIFY_DELETE_RESPONSE_TTL.as_secs() as u32,
-                prompt: false,
-            },
-            state.metrics.as_ref(),
-        )
-        .await
-        .map_err(Into::into)
-        .map_err(RelayMessageServerError::NotifyServer) // TODO change to client error?
+    let response_fut = {
+        let msg = msg.clone();
+        async {
+            let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
+                .map_err(RelayMessageServerError::EnvelopeEncryption)?;
+            let base64_notification =
+                base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+
+            publish_relay_message(
+                &state.relay_client,
+                &Publish {
+                    topic: msg.topic.clone(),
+                    message: base64_notification.into(),
+                    tag: NOTIFY_DELETE_RESPONSE_TAG,
+                    ttl_secs: NOTIFY_DELETE_RESPONSE_TTL.as_secs() as u32,
+                    prompt: false,
+                },
+                Some(msg),
+                state.metrics.as_ref(),
+                &state.analytics,
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(RelayMessageServerError::NotifyServer) // TODO change to client error?
+        }
     };
 
     if let Some(watchers_with_subscriptions) = watchers_with_subscriptions {
@@ -282,7 +289,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
                 &state.notify_keys.authentication_secret,
                 &state.notify_keys.authentication_client_id,
                 &state.relay_client,
+                msg,
                 state.metrics.as_ref(),
+                &state.analytics,
             )
             .await
             .map_err(RelayMessageServerError::SubscriptionWatcherSend)

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_get_notifications.rs
@@ -240,13 +240,15 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     publish_relay_message(
         &state.relay_client,
         &Publish {
-            topic: msg.topic,
+            topic: msg.topic.clone(),
             message: response.into(),
             tag: NOTIFY_GET_NOTIFICATIONS_RESPONSE_TAG,
             ttl_secs: NOTIFY_GET_NOTIFICATIONS_RESPONSE_TTL.as_secs() as u32,
             prompt: false,
         },
+        Some(Arc::new(msg)),
         state.metrics.as_ref(),
+        &state.analytics,
     )
     .await
     .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_mark_notifications_as_read.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_mark_notifications_as_read.rs
@@ -227,13 +227,15 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
     publish_relay_message(
         &state.relay_client,
         &Publish {
-            topic: msg.topic,
+            topic: msg.topic.clone(),
             message: response.into(),
             tag: NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TAG,
             ttl_secs: NOTIFY_MARK_NOTIFICATIONS_AS_READ_RESPONSE_TTL.as_secs() as u32,
             prompt: false,
         },
+        Some(Arc::new(msg)),
         state.metrics.as_ref(),
+        &state.analytics,
     )
     .await
     .map_err(|e| RelayMessageServerError::NotifyServer(e.into()))?; // TODO change to client error?

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_subscribe.rs
@@ -348,29 +348,36 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         ),
     };
 
-    let response_fut = async {
-        let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
-            .map_err(RelayMessageServerError::EnvelopeEncryption)?;
-        let base64_notification =
-            base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+    let msg = Arc::new(msg);
 
-        info!("Publishing subscribe response to topic: {response_topic}");
-        publish_relay_message(
-            &state.relay_client,
-            &Publish {
-                topic: response_topic,
-                message: base64_notification.into(),
-                tag: NOTIFY_SUBSCRIBE_RESPONSE_TAG,
-                ttl_secs: NOTIFY_SUBSCRIBE_RESPONSE_TTL.as_secs() as u32,
-                prompt: false,
-            },
-            state.metrics.as_ref(),
-        )
-        .await
-        .map_err(Into::into)
-        .map_err(RelayMessageServerError::NotifyServer)?; // TODO change to client error?
-        info!("Finished publishing subscribe response");
-        Ok(())
+    let response_fut = {
+        let msg = msg.clone();
+        async {
+            let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
+                .map_err(RelayMessageServerError::EnvelopeEncryption)?;
+            let base64_notification =
+                base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+
+            info!("Publishing subscribe response to topic: {response_topic}");
+            publish_relay_message(
+                &state.relay_client,
+                &Publish {
+                    topic: response_topic,
+                    message: base64_notification.into(),
+                    tag: NOTIFY_SUBSCRIBE_RESPONSE_TAG,
+                    ttl_secs: NOTIFY_SUBSCRIBE_RESPONSE_TTL.as_secs() as u32,
+                    prompt: false,
+                },
+                Some(msg),
+                state.metrics.as_ref(),
+                &state.analytics,
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(RelayMessageServerError::NotifyServer)?; // TODO change to client error?
+            info!("Finished publishing subscribe response");
+            Ok(())
+        }
     };
 
     if let Some(watchers_with_subscriptions) = watchers_with_subscriptions {
@@ -380,7 +387,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
                 &state.notify_keys.authentication_secret,
                 &state.notify_keys.authentication_client_id,
                 &state.relay_client,
+                msg,
                 state.metrics.as_ref(),
+                &state.analytics,
             )
             .await
             .map_err(RelayMessageServerError::SubscriptionWatcherSend)

--- a/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/handlers/notify_update.rs
@@ -249,26 +249,33 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
         ),
     };
 
-    let response_fut = async {
-        let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
-            .map_err(RelayMessageServerError::EnvelopeEncryption)?;
-        let base64_notification =
-            base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+    let msg = Arc::new(msg);
 
-        publish_relay_message(
-            &state.relay_client,
-            &Publish {
-                topic: msg.topic,
-                message: base64_notification.into(),
-                tag: NOTIFY_UPDATE_RESPONSE_TAG,
-                ttl_secs: NOTIFY_UPDATE_RESPONSE_TTL.as_secs() as u32,
-                prompt: false,
-            },
-            state.metrics.as_ref(),
-        )
-        .await
-        .map_err(Into::into)
-        .map_err(RelayMessageServerError::NotifyServer)
+    let response_fut = {
+        let msg = msg.clone();
+        async {
+            let envelope = Envelope::<EnvelopeType0>::new(&sym_key, response)
+                .map_err(RelayMessageServerError::EnvelopeEncryption)?;
+            let base64_notification =
+                base64::engine::general_purpose::STANDARD.encode(envelope.to_bytes());
+
+            publish_relay_message(
+                &state.relay_client,
+                &Publish {
+                    topic: msg.topic.clone(),
+                    message: base64_notification.into(),
+                    tag: NOTIFY_UPDATE_RESPONSE_TAG,
+                    ttl_secs: NOTIFY_UPDATE_RESPONSE_TTL.as_secs() as u32,
+                    prompt: false,
+                },
+                Some(msg),
+                state.metrics.as_ref(),
+                &state.analytics,
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(RelayMessageServerError::NotifyServer)
+        }
     };
 
     if let Some(watchers_with_subscriptions) = watchers_with_subscriptions {
@@ -278,7 +285,9 @@ pub async fn handle(msg: RelayIncomingMessage, state: &AppState) -> Result<(), R
                 &state.notify_keys.authentication_secret,
                 &state.notify_keys.authentication_client_id,
                 &state.relay_client,
+                msg,
                 state.metrics.as_ref(),
+                &state.analytics,
             )
             .await
             .map_err(RelayMessageServerError::SubscriptionWatcherSend)

--- a/src/services/public_http_server/handlers/relay_webhook/mod.rs
+++ b/src/services/public_http_server/handlers/relay_webhook/mod.rs
@@ -18,6 +18,7 @@ use {
         response::{IntoResponse, Response},
         Json,
     },
+    chrono::{DateTime, Utc},
     relay_rpc::{
         domain::Topic,
         jwt::{JwtError, VerifyableClaims},
@@ -145,8 +146,10 @@ pub async fn handler(
 
     let incoming_message = RelayIncomingMessage {
         topic: event.topic,
+        message_id: get_message_id(&event.message).into(),
         message: event.message,
         tag: event.tag,
+        received_at: Utc::now(),
     };
 
     if claims.act != WatchAction::WatchEvent {
@@ -171,9 +174,11 @@ pub struct RelayIncomingMessage {
     pub topic: Topic,
     pub message: Arc<str>,
     pub tag: u32,
+    pub message_id: Arc<str>,
+    pub received_at: DateTime<Utc>,
 }
 
-#[instrument(skip_all, fields(message_id = %get_message_id(&msg.message)))]
+#[instrument(skip_all, fields(message_id = %msg.message_id))]
 async fn handle_msg(
     msg: RelayIncomingMessage,
     state: &AppState,

--- a/src/services/publisher_service/mod.rs
+++ b/src/services/publisher_service/mod.rs
@@ -361,7 +361,7 @@ async fn process_notification(
         prompt: true,
     };
     let message_id = publish.msg_id();
-    publish_relay_message(relay_client, &publish, metrics)
+    publish_relay_message(relay_client, &publish, None, metrics, analytics)
         .await
         .map_err(ProcessNotificationError::RelayPublish)?;
 


### PR DESCRIPTION
# Description

Implements a data export that links relay requests to their responses. This allows is to better understand relay data on Notify-related messages and see user-experienced latency better.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
