### PR TITLE
fix: postgres version

### DIFF
--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -13,7 +13,7 @@ module "db_cluster" {
   name               = module.this.id
   database_name      = var.db_name
   engine             = "aurora-postgresql"
-  engine_version     = "15.3"
+  engine_version     = "15.4"
   engine_mode        = "provisioned"
   ca_cert_identifier = "rds-ca-ecc384-g1"
   instance_class     = "db.serverless"


### PR DESCRIPTION
# Description

CD is failing because AWS upgraded the Postgres version and it's no longer in-sync: https://github.com/WalletConnect/notify-server/actions/runs/8494688010/job/23270258501

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
