### PR TITLE
fix: less ignores for release

### DIFF
--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -7,10 +7,10 @@ on:
       - main
       - master
     paths-ignore:
-      - '.github/**'
+      # - '.github/**'
       - 'docs/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
+      # - 'Cargo.toml'
+      # - 'Cargo.lock'
       - 'README.md'
       - 'CHANGELOG.md'
       - 'LICENSE'


### PR DESCRIPTION
# Description

Bumping a dependency version or other configuration in Cargo.* or fixing something in a GitHub workflow doesn't trigger a release. The intention here was to avoid redundant deploys that weren't necessary, but this has caused more problems than it has solved over the months.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
