### PR TITLE
fix: if deploy-infra was set deploy-app would do nothing

### DIFF
--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -34,7 +34,7 @@ jobs:
     uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.9
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
-      deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
+      deploy-app: ${{ inputs.deploy-app }}
       version: ${{ inputs.version }}
       stage: staging
       stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
@@ -77,7 +77,7 @@ jobs:
     uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.9
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
-      deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
+      deploy-app: ${{ inputs.deploy-app }}
       version: ${{ inputs.version }}
       stage: prod
       stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health


### PR DESCRIPTION
# Description

Fixes that when doing deploys (either by hand or from a release), if an infra deploy was required, it wouldn't deploy the new app version (if required) at all.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
