### PR TITLE
fix: allow non-standard eip155 att key

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -607,7 +607,7 @@ pub enum IdentityVerificationError {
 
 #[derive(Debug, Error)]
 pub enum IdentityVerificationClientError {
-    #[error("CACAO not registered")]
+    #[error("iss not registered with Keys Server")]
     NotRegistered,
 
     #[error("ksu could not be parsed as URL: {0}")]

--- a/src/siwx/erc5573.rs
+++ b/src/siwx/erc5573.rs
@@ -88,7 +88,10 @@ pub fn parse_recap(
                                     .expect("Safe unwrap: Error should be caught in test cases")
                             });
                             for uri in recap.att.keys() {
-                                if URI_REGEX.captures(uri).is_none() {
+                                if URI_REGEX.captures(uri).is_none()
+                                    // https://walletconnect.slack.com/archives/C03RVH94K5K/p1713799617021109?thread_ts=1712839862.846379&cid=C03RVH94K5K
+                                    && uri != "eip155"
+                                {
                                     return Err(RecapParseError::InvalidUri(uri.clone()));
                                 }
                             }
@@ -149,6 +152,7 @@ pub mod test_utils {
 #[cfg(test)]
 mod tests {
     use {
+        self::test_utils::encode_recaip_uri,
         super::*,
         once_cell::sync::Lazy,
         serde_json::{json, Map, Number},
@@ -338,6 +342,82 @@ mod tests {
                 name: "delete".to_owned(),
             }])
         );
+    }
+
+    #[test]
+    fn allow_non_standard_eip155_att_key() {
+        // https://walletconnect.slack.com/archives/C03RVH94K5K/p1713799617021109?thread_ts=1712839862.846379&cid=C03RVH94K5K
+        let recap = serde_json::from_value::<ReCapDetailsObject>(json!({
+          "att": {
+            "eip155": {
+              "request/eth_sendRawTransaction": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/eth_sendTransaction": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/eth_sign": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/eth_signTransaction": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/eth_signTypedData": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/eth_signTypedData_v3": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/eth_signTypedData_v4": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ],
+              "request/personal_sign": [
+                {
+                  "chains": [
+                    "eip155:1"
+                  ]
+                }
+              ]
+            },
+            "https://notify.walletconnect.com": {
+              "manage/all-apps-notifications": [
+                {}
+              ]
+            }
+          }
+        }))
+        .unwrap();
+        let encoded = encode_recaip_uri(&recap);
+        let parsed = parse_recap(Some(&encoded)).unwrap().unwrap();
+        parsed.att.get("eip155").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
# Description

ERC-5573 requires that `att` keys be URIs, but our [own Sign 2.5 API isn't properly following this spec](https://walletconnect.slack.com/archives/C03RVH94K5K/p1713799617021109?thread_ts=1712839862.846379&cid=C03RVH94K5K). This PR temporarily allows this invalid value to unblock the team while we sort out a proper solution.

Also adjusts an error message to be [a little more understandable](https://walletconnect.slack.com/archives/C044SKFKELR/p1713785630296359?thread_ts=1713782285.406459&cid=C044SKFKELR).

## How Has This Been Tested?

New test case

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
