### PR TITLE
fix: switch watcher status to queued

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1185,7 +1185,7 @@ pub mod test_utils {
             )))
             .unwrap();
         let cacao_signature = [&signature.to_bytes()[..], &[recovery.to_byte()]].concat();
-        cacao.s.t = EIP191.to_owned();
+        EIP191.clone_into(&mut cacao.s.t);
         cacao.s.s = hex::encode(cacao_signature);
         cacao.verify(Some(&MockGetRpcUrl)).await.unwrap();
         cacao
@@ -1677,7 +1677,7 @@ pub mod test {
                 )))
                 .unwrap();
             let cacao_signature = [&signature.to_bytes()[..], &[recovery.to_byte()]].concat();
-            cacao.s.t = EIP191.to_owned();
+            EIP191.clone_into(&mut cacao.s.t);
             cacao.s.s = hex::encode(cacao_signature);
             cacao.verify(Some(&MockGetRpcUrl)).await.unwrap();
             cacao
@@ -1771,7 +1771,7 @@ pub mod test {
                 )))
                 .unwrap();
             let cacao_signature = [&signature.to_bytes()[..], &[recovery.to_byte()]].concat();
-            cacao.s.t = EIP191.to_owned();
+            EIP191.clone_into(&mut cacao.s.t);
             cacao.s.s = hex::encode(cacao_signature);
             cacao.verify(Some(&MockGetRpcUrl)).await.unwrap();
             cacao
@@ -1857,7 +1857,7 @@ pub mod test {
                 )))
                 .unwrap();
             let cacao_signature = [&signature.to_bytes()[..], &[recovery.to_byte()]].concat();
-            cacao.s.t = EIP191.to_owned();
+            EIP191.clone_into(&mut cacao.s.t);
             cacao.s.s = hex::encode(cacao_signature);
             cacao.verify(Some(&MockGetRpcUrl)).await.unwrap();
             cacao
@@ -1933,7 +1933,7 @@ pub mod test {
                 )))
                 .unwrap();
             let cacao_signature = [&signature.to_bytes()[..], &[recovery.to_byte()]].concat();
-            cacao.s.t = EIP191.to_owned();
+            EIP191.clone_into(&mut cacao.s.t);
             cacao.s.s = hex::encode(cacao_signature);
             cacao.verify(Some(&MockGetRpcUrl)).await.unwrap();
             cacao

--- a/src/services/relay_renewal_job/register_webhook.rs
+++ b/src/services/relay_renewal_job/register_webhook.rs
@@ -111,7 +111,7 @@ mod tests {
                 );
                 assert_eq!(claims.typ, WatchType::Subscriber);
                 assert_eq!(claims.act, WatchAction::Register);
-                assert_eq!(claims.sts, vec![WatchStatus::Queued]);
+                assert_eq!(claims.sts, vec![WatchStatus::Accepted]);
                 const LEEWAY: i64 = 2;
                 let expected_iat = Utc::now().timestamp();
                 assert!(claims.basic.iat <= expected_iat);

--- a/src/services/relay_renewal_job/register_webhook.rs
+++ b/src/services/relay_renewal_job/register_webhook.rs
@@ -31,7 +31,7 @@ pub async fn run(
                 tags: INCOMING_TAGS.to_vec(),
                 // Alternatively we could not care about the tag, as an incoming message is an incoming message
                 // tags: (4000..4100).collect(),
-                statuses: vec![WatchStatus::Queued],
+                statuses: vec![WatchStatus::Accepted],
                 ttl: Duration::from_secs(60 * 60 * 24 * 30),
             },
             keypair,

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ To authenticate, run `terraform login` and follow the instructions.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.46.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.47.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 ## Modules


### PR DESCRIPTION
# Description

Switches the webhook status from queued to accepted since this is subject to additional performance optimizations. [Slack conversation](https://walletconnect.slack.com/archives/C03SMNKLPU0/p1714141690313319?thread_ts=1713941199.429849&cid=C03SMNKLPU0)

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
