### PR TITLE
fix: only remove from mailbox after queued event

### DIFF
--- a/src/services/relay_renewal_job/register_webhook.rs
+++ b/src/services/relay_renewal_job/register_webhook.rs
@@ -31,7 +31,8 @@ pub async fn run(
                 tags: INCOMING_TAGS.to_vec(),
                 // Alternatively we could not care about the tag, as an incoming message is an incoming message
                 // tags: (4000..4100).collect(),
-                statuses: vec![WatchStatus::Accepted],
+                // Accepted webhook to handle the message, Queued webhook to remove message from mailbox
+                statuses: vec![WatchStatus::Accepted, WatchStatus::Queued],
                 ttl: Duration::from_secs(60 * 60 * 24 * 30),
             },
             keypair,
@@ -111,7 +112,7 @@ mod tests {
                 );
                 assert_eq!(claims.typ, WatchType::Subscriber);
                 assert_eq!(claims.act, WatchAction::Register);
-                assert_eq!(claims.sts, vec![WatchStatus::Accepted]);
+                assert_eq!(claims.sts, vec![WatchStatus::Accepted, WatchStatus::Queued]);
                 const LEEWAY: i64 = 2;
                 let expected_iat = Utc::now().timestamp();
                 assert!(claims.basic.iat <= expected_iat);


### PR DESCRIPTION
# Description

Fixes this issue raised by Ivan:

> hey, regarding the [`queued` -> `accepted` change in notify server that you made](https://github.com/WalletConnect/notify-server/pull/526): there's a problem now with how the messages are removed using the irn_batchReceive where the message may not yet be in the mailbox when notify tries to remove it

Solution as suggested is to subscribe to both. When `accepted` is received, handle the message. And when `queued` is received, remove the message from the relay mailbox.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
