### PR TITLE
fix: account analytics

### DIFF
--- a/src/analytics/get_notifications.rs
+++ b/src/analytics/get_notifications.rs
@@ -41,6 +41,8 @@ pub struct GetNotifications {
     pub project_id: Arc<str>,
     /// Primary Key of the subscriber in the Notify Server database
     pub subscriber_pk: String,
+    /// The CAIP-10 account of the subscriber
+    pub subscriber_account: String,
     /// Hash of the CAIP-10 account of the subscriber
     pub subscriber_account_hash: String,
     /// The topic that notifications are sent on
@@ -66,6 +68,7 @@ impl From<GetNotificationsParams> for GetNotifications {
             project_pk: params.project_pk.to_string(),
             project_id: params.project_id.into_value(),
             subscriber_pk: params.subscriber_pk.to_string(),
+            subscriber_account: params.subscriber_account.to_string(),
             subscriber_account_hash: sha256::digest(params.subscriber_account.as_ref()),
             notification_topic: params.notification_topic.into_value(),
             subscriber_notification_id: params.subscriber_notification_pk.to_string(),

--- a/src/analytics/mark_notifications_as_read.rs
+++ b/src/analytics/mark_notifications_as_read.rs
@@ -40,6 +40,8 @@ pub struct MarkNotificationsAsRead {
     pub project_id: Arc<str>,
     /// Primary Key of the subscriber in the Notify Server database
     pub subscriber_pk: String,
+    /// The CAIP-10 account of the subscriber
+    pub subscriber_account: String,
     /// Hash of the CAIP-10 account of the subscriber
     pub subscriber_account_hash: String,
     /// The topic that notifications are sent on
@@ -63,6 +65,7 @@ impl From<MarkNotificationsAsReadParams> for MarkNotificationsAsRead {
             project_pk: params.project_pk.to_string(),
             project_id: params.project_id.into_value(),
             subscriber_pk: params.subscriber_pk.to_string(),
+            subscriber_account: params.subscriber_account.to_string(),
             subscriber_account_hash: sha256::digest(params.subscriber_account.as_ref()),
             notification_topic: params.notification_topic.into_value(),
             subscriber_notification_pk: params.subscriber_notification_pk.to_string(),

--- a/src/analytics/notification_link.rs
+++ b/src/analytics/notification_link.rs
@@ -29,6 +29,8 @@ pub struct NotificationLink {
     pub project_id: Arc<str>,
     /// Primary key of the subscriber in the Notify Server database
     pub subscriber_pk: String,
+    /// The CAIP-10 account of the subscriber
+    pub subscriber_account: String,
     /// Hash of the CAIP-10 account of the subscriber
     pub subscriber_account_hash: String,
     /// The topic that notifications are sent on
@@ -63,6 +65,7 @@ impl From<NotificationLinkParams> for NotificationLink {
             project_pk: params.project_pk.to_string(),
             project_id: params.project_id.into_value(),
             subscriber_pk: params.subscriber_pk.to_string(),
+            subscriber_account: params.subscriber_account.to_string(),
             subscriber_account_hash: sha256::digest(params.subscriber_account.as_ref()),
             notification_topic: params.notification_topic.into_value(),
             subscriber_notification_id: params.subscriber_notification_pk.to_string(),

--- a/src/analytics/subscriber_notification.rs
+++ b/src/analytics/subscriber_notification.rs
@@ -29,6 +29,8 @@ pub struct SubscriberNotification {
     pub project_id: Arc<str>,
     /// Primary key of the subscriber in the Notify Server database that the notificaiton is being sent to
     pub subscriber_pk: String,
+    /// The CAIP-10 account of the subscriber
+    pub account: String,
     /// Hash of the CAIP-10 account of the subscriber
     pub account_hash: String,
     /// The ID of the subscriber-specific notification
@@ -50,6 +52,7 @@ impl From<SubscriberNotificationParams> for SubscriberNotification {
             project_pk: params.project_pk.to_string(),
             project_id: params.project_id.into_value(),
             subscriber_pk: params.subscriber_pk.to_string(),
+            account: params.account.to_string(),
             account_hash: sha256::digest(params.account.as_ref()),
             subscriber_notification_pk: params.subscriber_notification_pk.to_string(),
             notification_pk: params.notification_pk.to_string(),

--- a/src/analytics/subscriber_update.rs
+++ b/src/analytics/subscriber_update.rs
@@ -52,6 +52,8 @@ pub struct SubscriberUpdate {
     pub project_id: Arc<str>,
     /// Primary Key of the subscriber in the Notify Server database
     pub pk: String,
+    /// The CAIP-10 account of the subscriber
+    pub account: String,
     /// Hash of the CAIP-10 account of the subscriber
     pub account_hash: String,
     /// JWT iss that made the update
@@ -77,6 +79,7 @@ impl From<SubscriberUpdateParams> for SubscriberUpdate {
             project_pk: params.project_pk.to_string(),
             project_id: params.project_id.into_value(),
             pk: params.pk.to_string(),
+            account: params.account.to_string(),
             account_hash: sha256::digest(params.account.as_ref()),
             updated_by_iss: params.updated_by_iss,
             updated_by_domain: params.updated_by_domain,


### PR DESCRIPTION
# Description

Adds the raw account ID to the analytics export. This is already included in our [privacy policy](https://walletconnect.com/privacy) so no changes are necessary there.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
